### PR TITLE
Provide secret with specific name to all KubeComputes

### DIFF
--- a/pkg/orchestration/wiring/k8scompute/api/api.go
+++ b/pkg/orchestration/wiring/k8scompute/api/api.go
@@ -8,4 +8,8 @@ const (
 	// hard coded this secret to be able to pull images from docker-atl-paas
 	// we will revisit this later for more generic approach
 	DockerImagePullName = "kubecompute-docker-atl-paas"
+
+	// CommonSecretName is the name of a secret all computes for a particular
+	// namespace will have in envFrom
+	CommonSecretName = "common-secrets"
 )

--- a/pkg/orchestration/wiring/k8scompute/plugin.go
+++ b/pkg/orchestration/wiring/k8scompute/plugin.go
@@ -238,6 +238,18 @@ func WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext
 	// regardless if they're using ASAP or not
 	envDefault = append(envDefault, asapkey.GetPublicKeyRepoEnvVars(context.StateContext.Location)...)
 
+	// always bind to the common secret, it's OK if it doesn't exist
+	trueVar := true
+	commonEnvFrom := core_v1.EnvFromSource{
+		SecretRef: &core_v1.SecretEnvSource{
+			LocalObjectReference: core_v1.LocalObjectReference{
+				Name: apik8scompute.CommonSecretName,
+			},
+			Optional: &trueVar,
+		},
+	}
+	envFrom = append(envFrom, commonEnvFrom)
+
 	// prepare containers
 	containers := buildContainers(spec, envDefault, envFrom)
 

--- a/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
@@ -170,6 +170,9 @@ spec:
                 - secretRef:
                     name: '!{kubecompute-simple--podsecretenvvar-metadata-name}'
                     optional: false
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 image: docker.atl-paas.net/atlassian/micros-analytics:0.1
                 name: microservice
                 ports:

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
@@ -64,6 +64,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 name: microservice
                 image: "docker.atl-paas.net/atlassian/micros-analytics:0.1"
                 imagePullPolicy: IfNotPresent
@@ -104,6 +108,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 name: pgbouncer
                 image: "docker.atl-paas.net/my_pgbouncer:abcxyz"
                 imagePullPolicy: IfNotPresent
@@ -132,6 +140,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 name: sidecar
                 image: "docker.atl-paas.net/my_sidecar:abcxyz"
                 imagePullPolicy: IfNotPresent

--- a/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
@@ -64,6 +64,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 name: microservice
                 image: "docker.atl-paas.net/atlassian/micros-analytics:0.1"
                 imagePullPolicy: IfNotPresent
@@ -84,6 +88,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 name: pgbouncer
                 image: "docker.atl-paas.net/my_pgbouncer:abcxyz"
                 imagePullPolicy: IfNotPresent

--- a/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
@@ -64,6 +64,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 name: microservice
                 image: "docker.atl-paas.net/atlassian/micros-analytics:0.1"
                 imagePullPolicy: IfNotPresent
@@ -84,6 +88,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 name: pgbouncer
                 image: "docker.atl-paas.net/my_pgbouncer:abcxyz"
                 imagePullPolicy: IfNotPresent

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
@@ -63,6 +63,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 image: docker.atl-paas.net/atlassian/micros-analytics:0.1.8
                 imagePullPolicy: IfNotPresent
                 name: microservice

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
@@ -63,6 +63,10 @@ spec:
                   value: https://asap-distribution.us-west-1.staging.paas-inf.net/
                 - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
                   value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
                 image: docker.atl-paas.net/atlassian/micros-analytics:0.1.8
                 imagePullPolicy: IfNotPresent
                 name: microservice


### PR DESCRIPTION
* Always bind to a specific secret name from within KubeCompute
* Set Reference as optional so that secret doesn't need to exist
