### PR TITLE
send alarm endpoints as a list in rds autowiring

### DIFF
--- a/pkg/orchestration/wiring/testdata/postgres.customrds.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/postgres.customrds.bundle.yaml
@@ -42,6 +42,15 @@ spec:
             parameters:
               RDSType: postgres961
             primary_parameters:
+              MicrosAlarmEndpoints:
+              - consumer: pagerduty
+                endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/12312312312312312312312312312312
+                priority: high
+                type: CloudWatch
+              - consumer: pagerduty
+                endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/12312312312312312312312312312312
+                priority: low
+                type: CloudWatch
               MicrosAppSubnets:
               - subnet-1
               - subnet-2

--- a/pkg/orchestration/wiring/testdata/rds.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/rds.bundle.yaml
@@ -44,6 +44,15 @@ spec:
                 resource_owner: an_owner
                 service_name: test-servicename
             primary_parameters:
+              MicrosAlarmEndpoints:
+                - consumer: pagerduty
+                  endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/12312312312312312312312312312312
+                  priority: high
+                  type: CloudWatch
+                - consumer: pagerduty
+                  endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/12312312312312312312312312312312
+                  priority: low
+                  type: CloudWatch
               MicrosAppSubnets:
               - subnet-1
               - subnet-2

--- a/pkg/orchestration/wiring/testdata/rds.servicename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/rds.servicename.bundle.yaml
@@ -44,6 +44,15 @@ spec:
                 resource_owner: an_owner
                 service_name: test-servicename
             primary_parameters:
+              MicrosAlarmEndpoints:
+              - type: CloudWatch
+                consumer: pagerduty
+                priority: high
+                endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/12312312312312312312312312312312
+              - type: CloudWatch
+                consumer: pagerduty
+                priority: low
+                endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/12312312312312312312312312312312
               MicrosAppSubnets:
               - subnet-1
               - subnet-2


### PR DESCRIPTION
The format of alarms is going to change from explicit endpoints (MicrosPagerdutyHigh, MicrosPagerdutyLow) to an arbitrary list (MicrosAlarmEndpoints).

The new list format isn't ready in Voyager so we'll emulate it in the autowiring function.