### PR TITLE
Change to always trying to create the common secret

### DIFF
--- a/pkg/synchronization/BUILD.bazel
+++ b/pkg/synchronization/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "//vendor/go.uber.org/zap/zaptest:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",


### PR DESCRIPTION
* Create and handle AlreadyExists error rather than NotExists
* Requires fewer permissions (create only rather than get)