### PR TITLE
Build race binaries instead of pure ones by default

### DIFF
--- a/cmd/cmd.bzl
+++ b/cmd/cmd.bzl
@@ -6,6 +6,7 @@ def define_command_targets(name, binary_embed):
         name = name,
         embed = binary_embed,
         pure = "on",
+        tags = ["manual"],
         visibility = ["//visibility:public"],
     )
 
@@ -13,7 +14,6 @@ def define_command_targets(name, binary_embed):
         name = name + "_race",
         embed = binary_embed,
         race = "on",
-        tags = ["manual"],
         visibility = ["//visibility:public"],
     )
 

--- a/cmd/crd/BUILD.bazel
+++ b/cmd/crd/BUILD.bazel
@@ -20,6 +20,6 @@ go_library(
 go_binary(
     name = "crd",
     embed = [":go_default_library"],
-    pure = "on",
+    race = "on",
     visibility = ["//visibility:public"],
 )

--- a/cmd/showenv/BUILD.bazel
+++ b/cmd/showenv/BUILD.bazel
@@ -19,7 +19,7 @@ go_library(
 go_binary(
     name = "showenv",
     embed = [":go_default_library"],
-    pure = "on",
+    race = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Tests are built in race mode. If binaries are built in pure mode then all libraries are built twice.

Look at number of actions and elapsed time. Both runs were executed after bazel clean.

Before:
```console
bazel test \
                --test_env=KUBE_PATCH_CONVERSION_DETECTOR=true \
                --test_env=KUBE_CACHE_MUTATION_DETECTOR=true \
                -- //... -//vendor/... -//build/...

INFO: Elapsed time: 277.778s, Critical Path: 124.45s
INFO: 2796 processes: 2796 darwin-sandbox.
INFO: Build completed successfully, 2932 total actions
```
After:
```console
bazel test \
                --test_env=KUBE_PATCH_CONVERSION_DETECTOR=true \
                --test_env=KUBE_CACHE_MUTATION_DETECTOR=true \
                -- //... -//vendor/... -//build/...

INFO: Elapsed time: 243.550s, Critical Path: 127.96s
INFO: 2334 processes: 2334 darwin-sandbox.
INFO: Build completed successfully, 2470 total actions
```
This is the same change as https://github.com/atlassian/smith/pull/398.