### PR TITLE
Add anti-affinity and pod disruption budget for kubecompute services

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1681,6 +1681,7 @@
     "k8s.io/api/autoscaling/v2beta1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
+    "k8s.io/api/policy/v1beta1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -38,6 +38,18 @@ const (
 	WatchVerb            = "watch"
 
 	ServiceDescriptorClaimVerb = "claim"
+
+	// Beta labels, from:
+	// https://github.com/kubernetes/kubernetes/blob/v1.12.2/pkg/kubelet/apis/well_known_labels.go
+	LabelHostname           = "kubernetes.io/hostname"
+	LabelZoneFailureDomain  = "failure-domain.beta.kubernetes.io/zone"
+	LabelMultiZoneDelimiter = "__"
+	LabelZoneRegion         = "failure-domain.beta.kubernetes.io/region"
+
+	LabelInstanceType = "beta.kubernetes.io/instance-type"
+
+	LabelOS   = "beta.kubernetes.io/os"
+	LabelArch = "beta.kubernetes.io/arch"
 )
 
 var (

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -15,6 +15,7 @@ const (
 	DeploymentKind              = "Deployment"
 	NamespaceKind               = "Namespace"
 	PodKind                     = "Pod"
+	PodDisruptionBudgetKind     = "PodDisruptionBudget"
 	ReplicaSetKind              = "ReplicaSet"
 	RoleKind                    = "Role"
 	RoleBindingKind             = "RoleBinding"

--- a/pkg/orchestration/wiring/k8scompute/BUILD.bazel
+++ b/pkg/orchestration/wiring/k8scompute/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v2beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/orchestration/wiring/k8scompute/plugin.go
+++ b/pkg/orchestration/wiring/k8scompute/plugin.go
@@ -528,7 +528,7 @@ func buildAntiAffinity(resourceName voyager.ResourceName) *core_v1.PodAntiAffini
 				LabelSelector: &meta_v1.LabelSelector{
 					MatchExpressions: matchExpressions,
 				},
-				TopologyKey: "failure-domain.beta.kubernetes.io/zone",
+				TopologyKey: k8s.LabelZoneFailureDomain,
 			},
 		},
 		core_v1.WeightedPodAffinityTerm{
@@ -537,7 +537,7 @@ func buildAntiAffinity(resourceName voyager.ResourceName) *core_v1.PodAntiAffini
 				LabelSelector: &meta_v1.LabelSelector{
 					MatchExpressions: matchExpressions,
 				},
-				TopologyKey: "kubernetes.io/hostname",
+				TopologyKey: k8s.LabelHostname,
 			},
 		},
 	}

--- a/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
@@ -161,6 +161,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -193,4 +214,20 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
@@ -117,6 +117,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--podsecretenvvar-metadata-name
@@ -171,6 +184,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -180,6 +197,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -214,20 +235,4 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
@@ -924,6 +924,27 @@ spec:
                 resourceName: kc
                 stateName: noderefapp
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kc
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kc
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -955,6 +976,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kc--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kc--pdb
+    references:
+    - name: kc-metadata-name
+      path: metadata.name
+      resource: kc
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kc--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kc
   - name: kc--hpa
     references:
     - name: kc-metadata-name

--- a/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
@@ -880,6 +880,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kc--svcacc
+  - name: kc--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kc--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kc
+              stateName: noderefapp
   - name: kc
     references:
     - name: kc--podsecretenvvar-metadata-name
@@ -934,6 +947,10 @@ spec:
                           operator: In
                           values:
                           - kc
+                        - key: stateName
+                          operator: In
+                          values:
+                          - noderefapp
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -943,6 +960,10 @@ spec:
                           operator: In
                           values:
                           - kc
+                        - key: stateName
+                          operator: In
+                          values:
+                          - noderefapp
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -976,22 +997,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kc--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kc--pdb
-    references:
-    - name: kc-metadata-name
-      path: metadata.name
-      resource: kc
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kc--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kc
   - name: kc--hpa
     references:
     - name: kc-metadata-name

--- a/pkg/orchestration/wiring/testdata/internaldns.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/internaldns.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -105,22 +126,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: ingress--service
     references:
     - resource: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/internaldns.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/internaldns.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -84,6 +105,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: ingress--service
     references:
     - resource: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/internaldns.multiplealias.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/internaldns.multiplealias.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -105,22 +126,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: ingress--service
     references:
     - resource: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/internaldns.multiplealias.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/internaldns.multiplealias.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -84,6 +105,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: ingress--service
     references:
     - resource: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/internaldns.multipleresources.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/internaldns.multipleresources.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: c1
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - c1
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - c1
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -84,6 +105,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{c1--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: c1--pdb
+    references:
+    - name: c1-metadata-name
+      path: metadata.name
+      resource: c1
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: c1--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: c1
   - name: c2--svcacc
     spec:
       object:
@@ -128,6 +165,27 @@ spec:
                 resourceName: c2
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - c2
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - c2
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -155,6 +213,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{c2--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: c2--pdb
+    references:
+    - name: c2-metadata-name
+      path: metadata.name
+      resource: c2
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: c2--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: c2
   - name: ingress1--service
     references:
     - resource: c1

--- a/pkg/orchestration/wiring/testdata/internaldns.multipleresources.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/internaldns.multipleresources.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: c1--svcacc
+  - name: c1--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: c1--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: c1
+              stateName: state1
   - name: c1
     references:
     - name: c1--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - c1
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - c1
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -105,22 +126,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{c1--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: c1--pdb
-    references:
-    - name: c1-metadata-name
-      path: metadata.name
-      resource: c1
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: c1--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: c1
   - name: c2--svcacc
     spec:
       object:
@@ -130,6 +135,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: c2--svcacc
+  - name: c2--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: c2--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: c2
+              stateName: state1
   - name: c2
     references:
     - name: c2--svcacc-metadata-name
@@ -175,6 +193,10 @@ spec:
                           operator: In
                           values:
                           - c2
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -184,6 +206,10 @@ spec:
                           operator: In
                           values:
                           - c2
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -213,22 +239,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{c2--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: c2--pdb
-    references:
-    - name: c2-metadata-name
-      path: metadata.name
-      resource: c2
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: c2--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: c2
   - name: ingress1--service
     references:
     - resource: c1

--- a/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
@@ -172,6 +172,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: keyFromConfigMap
@@ -242,6 +263,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
@@ -128,6 +128,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--podsecretenvvar-metadata-name
@@ -182,6 +195,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -191,6 +208,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -263,22 +284,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
@@ -172,6 +172,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: keyFromConfigMap
@@ -239,4 +260,20 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
@@ -128,6 +128,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--podsecretenvvar-metadata-name
@@ -182,6 +195,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -191,6 +208,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -260,20 +281,4 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
@@ -172,6 +172,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: keyFromConfigMap
@@ -242,4 +263,20 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
@@ -128,6 +128,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--podsecretenvvar-metadata-name
@@ -182,6 +195,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -191,6 +208,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -263,20 +284,4 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -195,22 +216,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
@@ -13,7 +13,7 @@ metadata:
     uid: 411c0040-617e-11e7-9b57-427d691976d7
 spec:
   resources:
-  - name: kubecompute-probes--svcacc
+  - name: kubecompute-simple--svcacc
     spec:
       object:
         apiVersion: v1
@@ -21,25 +21,25 @@ spec:
         - name: kubecompute-docker-atl-paas
         kind: ServiceAccount
         metadata:
-          name: kubecompute-probes--svcacc
-  - name: kubecompute-probes
+          name: kubecompute-simple--svcacc
+  - name: kubecompute-simple
     references:
-    - name: kubecompute-probes--svcacc-metadata-name
+    - name: kubecompute-simple--svcacc-metadata-name
       path: metadata.name
-      resource: kubecompute-probes--svcacc
+      resource: kubecompute-simple--svcacc
     spec:
       object:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: kubecompute-probes
+          name: kubecompute-simple
         spec:
           progressDeadlineSeconds: 600
           replicas: 1
           revisionHistoryLimit: 0
           selector:
             matchLabels:
-              resourceName: kubecompute-probes
+              resourceName: kubecompute-simple
               stateName: state1
           strategy:
             rollingUpdate:
@@ -54,9 +54,30 @@ spec:
                 atlassian.com/resource_owner: an_owner
               creationTimestamp: null
               labels:
-                resourceName: kubecompute-probes
+                resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -172,19 +193,35 @@ spec:
               restartPolicy: Always
               schedulerName: default-scheduler
               securityContext: {}
-              serviceAccountName: '!{kubecompute-probes--svcacc-metadata-name}'
+              serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-probes--hpa
+  - name: kubecompute-simple--pdb
     references:
-    - name: kubecompute-probes-metadata-name
+    - name: kubecompute-simple-metadata-name
       path: metadata.name
-      resource: kubecompute-probes
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+  - name: kubecompute-simple--hpa
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
     spec:
       object:
         apiVersion: autoscaling/v2beta1
         kind: HorizontalPodAutoscaler
         metadata:
-          name: kubecompute-probes--hpa
+          name: kubecompute-simple--hpa
         spec:
           maxReplicas: 5
           metrics:
@@ -196,5 +233,5 @@ spec:
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: '!{kubecompute-probes-metadata-name}'
+            name: '!{kubecompute-simple-metadata-name}'
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
@@ -128,6 +128,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--podsecretenvvar-metadata-name
@@ -182,6 +195,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -191,6 +208,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -260,20 +281,4 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
@@ -172,6 +172,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -239,4 +260,20 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.state.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.state.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   resources:
   - type: KubeCompute
-    name: kubecompute-probes
+    name: kubecompute-simple
     defaults:
       filledInBy: "Formation layer"
       replicas: 1

--- a/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
@@ -131,6 +131,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--podsecretenvvar-metadata-name
@@ -185,6 +198,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -194,6 +211,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -230,22 +251,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
@@ -175,6 +175,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -209,6 +230,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
@@ -172,6 +172,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: keyFromConfigMap
@@ -242,6 +263,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
@@ -128,6 +128,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--podsecretenvvar-metadata-name
@@ -182,6 +195,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -191,6 +208,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -263,22 +284,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -133,22 +154,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -112,6 +133,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -133,22 +154,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -112,6 +133,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -85,6 +106,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -106,22 +127,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -85,6 +106,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -106,22 +127,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -85,6 +106,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -106,22 +127,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
@@ -57,6 +57,27 @@ spec:
                 resourceName: kubecompute-simple
                 stateName: state1
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: failure-domain.beta.kubernetes.io/zone
+                    weight: 75
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: resourceName
+                          operator: In
+                          values:
+                          - kubecompute-simple
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               containers:
               - env:
                 - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
@@ -85,6 +106,22 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: kubecompute-simple--pdb
+    references:
+    - name: kubecompute-simple-metadata-name
+      path: metadata.name
+      resource: kubecompute-simple
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
@@ -22,6 +22,19 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
+  - name: kubecompute-simple--pdb
+    spec:
+      object:
+        apiVersion: policy/v1beta1
+        kind: PodDisruptionBudget
+        metadata:
+          name: kubecompute-simple--pdb
+        spec:
+          minAvailable: 30%
+          selector:
+            matchLabels:
+              resourceName: kubecompute-simple
+              stateName: state1
   - name: kubecompute-simple
     references:
     - name: kubecompute-simple--svcacc-metadata-name
@@ -67,6 +80,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 75
                   - podAffinityTerm:
@@ -76,6 +93,10 @@ spec:
                           operator: In
                           values:
                           - kubecompute-simple
+                        - key: stateName
+                          operator: In
+                          values:
+                          - state1
                       topologyKey: kubernetes.io/hostname
                     weight: 50
               containers:
@@ -106,22 +127,6 @@ spec:
               securityContext: {}
               serviceAccountName: '!{kubecompute-simple--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: kubecompute-simple--pdb
-    references:
-    - name: kubecompute-simple-metadata-name
-      path: metadata.name
-      resource: kubecompute-simple
-    spec:
-      object:
-        apiVersion: policy/v1beta1
-        kind: PodDisruptionBudget
-        metadata:
-          name: kubecompute-simple--pdb
-        spec:
-          minAvailable: 30%
-          selector:
-            matchLabels:
-              resourceName: kubecompute-simple
   - name: kubecompute-simple--hpa
     references:
     - name: kubecompute-simple-metadata-name


### PR DESCRIPTION
This should set sensible defaults to prefer scheduling pods across zones, and then nodes where possible, with a pod disruption budget of 30%.