### PR TITLE
VYGR-368: Annotate postgres resource with deletion delay

### DIFF
--- a/pkg/orchestration/wiring/postgres/BUILD.bazel
+++ b/pkg/orchestration/wiring/postgres/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/orchestration/wiring/wiringplugin:go_default_library",
         "//pkg/orchestration/wiring/wiringutil:go_default_library",
         "//pkg/orchestration/wiring/wiringutil/svccatentangler:go_default_library",
+        "//vendor/github.com/atlassian/smith:go_default_library",
         "//vendor/github.com/atlassian/smith/pkg/apis/smith/v1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/orchestration/wiring/postgres/plugin.go
+++ b/pkg/orchestration/wiring/postgres/plugin.go
@@ -3,7 +3,9 @@ package postgres
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/atlassian/smith"
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/voyager"
 	orch_v1 "github.com/atlassian/voyager/pkg/apis/orchestration/v1"
@@ -21,6 +23,7 @@ const (
 
 	clusterServiceClassExternalID = "8e14a988-0532-49ed-a6cd-31fa0c0fb2a8"
 	clusterServicePlanExternalID  = "10aa2cb5-897d-43f6-b0df-ac4f8a2a758e"
+	deletionDelay                 = 7 * 24 * time.Hour
 
 	postgresEnvResourcePrefix = "pg"
 )
@@ -120,7 +123,7 @@ func instanceSpec(resource *orch_v1.StateResource, context *wiringplugin.WiringC
 		}
 	}
 
-	// Build final spec, by combining calculated varaibles + user provided variables
+	// Build final spec, by combining calculated variables + user provided variables
 	var finalSpec map[string]interface{}
 
 	// Insert calculated variables
@@ -185,6 +188,7 @@ func objectMeta(resource *orch_v1.StateResource, context *wiringplugin.WiringCon
 	return meta_v1.ObjectMeta{
 		Annotations: map[string]string{
 			voyager.Domain + "/envResourcePrefix": postgresEnvResourcePrefix,
+			smith.DeletionDelayAnnotation:         deletionDelay.String(),
 		},
 	}, nil
 }

--- a/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
@@ -327,6 +327,7 @@ spec:
         metadata:
           annotations:
             voyager.atl-paas.net/envResourcePrefix: pg
+            smith.atlassian.com/deletionDelay: 168h0m0s
           name: datastore
         spec:
           clusterServiceClassExternalID: 8e14a988-0532-49ed-a6cd-31fa0c0fb2a8

--- a/pkg/orchestration/wiring/testdata/postgres.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/postgres.bundle.yaml
@@ -21,6 +21,7 @@ spec:
         metadata:
           annotations:
             voyager.atl-paas.net/envResourcePrefix: pg
+            smith.atlassian.com/deletionDelay: 168h0m0s
           name: db
         spec:
           clusterServiceClassExternalID: 8e14a988-0532-49ed-a6cd-31fa0c0fb2a8

--- a/pkg/orchestration/wiring/testdata/postgres.customrds.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/postgres.customrds.bundle.yaml
@@ -78,6 +78,7 @@ spec:
         metadata:
           annotations:
             voyager.atl-paas.net/envResourcePrefix: pg
+            smith.atlassian.com/deletionDelay: 168h0m0s
           name: db
         spec:
           clusterServiceClassExternalID: 8e14a988-0532-49ed-a6cd-31fa0c0fb2a8

--- a/pkg/orchestration/wiring/testdata/postgres.dependsons3.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/postgres.dependsons3.bundle.yaml
@@ -40,6 +40,7 @@ spec:
         metadata:
           annotations:
             voyager.atl-paas.net/envResourcePrefix: pg
+            smith.atlassian.com/deletionDelay: 168h0m0s
           name: db
         spec:
           clusterServiceClassExternalID: 8e14a988-0532-49ed-a6cd-31fa0c0fb2a8

--- a/pkg/orchestration/wiring/testdata/postgres.existing.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/postgres.existing.bundle.yaml
@@ -21,6 +21,7 @@ spec:
         metadata:
           annotations:
             voyager.atl-paas.net/envResourcePrefix: pg
+            smith.atlassian.com/deletionDelay: 168h0m0s
           name: adb
         spec:
           clusterServiceClassExternalID: 8e14a988-0532-49ed-a6cd-31fa0c0fb2a8

--- a/pkg/orchestration/wiring/testdata/postgres.servicename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/postgres.servicename.bundle.yaml
@@ -21,6 +21,7 @@ spec:
         metadata:
           annotations:
             voyager.atl-paas.net/envResourcePrefix: pg
+            smith.atlassian.com/deletionDelay: 168h0m0s
           name: adb
         spec:
           clusterServiceClassExternalID: 8e14a988-0532-49ed-a6cd-31fa0c0fb2a8


### PR DESCRIPTION
**Soft Delete Design docs**: https://github.com/atlassian/smith/blob/master/docs/design/soft-deletes.md
**Why:** Prevent unintended deletions of postgres resources

**What:**
- Set postgres deletion delay to one week
- Import time
- Import github.com/atlassian/smith

Signed-off-by: Fraser Cobb <fcobb@atlassian.com>