### PR TITLE
Add docs and make optionalShapes consistent in SvcCatEntangler

### DIFF
--- a/pkg/orchestration/wiring/asapkey/plugin.go
+++ b/pkg/orchestration/wiring/asapkey/plugin.go
@@ -45,13 +45,13 @@ func New() *WiringPlugin {
 			InstanceSpec:                  instanceSpec,
 			ObjectMeta:                    objectMeta,
 			ResourceType:                  ResourceType,
-			OptionalShapes:                optionalShapes,
+			AdditionalShapes:              additionalShapes,
 		},
 	}
 }
 
 // optionalShapes returns a list of Shapes that the ASAPKey wiring plugin could output
-func optionalShapes(_ *orch_v1.StateResource, smithResource *smith_v1.Resource, _ *wiringplugin.WiringContext) ([]wiringplugin.Shape, error) {
+func additionalShapes(_ *orch_v1.StateResource, _ *smith_v1.Resource, _ *wiringplugin.WiringContext) ([]wiringplugin.Shape, error) {
 	return []wiringplugin.Shape{
 		knownshapes.NewASAPKey(),
 	}, nil

--- a/pkg/orchestration/wiring/aws/plugin.go
+++ b/pkg/orchestration/wiring/aws/plugin.go
@@ -37,14 +37,14 @@ func Resource(resourceType voyager.ResourceType,
 	clusterServicePlanExternalID servicecatalog.PlanExternalID,
 	generateServiceEnvironment ServiceEnvironmentGenerator,
 	envResourcePrefix oap.EnvVarPrefix,
-	optionalShapes svccatentangler.OptionalShapeFunc,
+	additionalShapes svccatentangler.AdditionalShapesFunc,
 ) *WiringPlugin {
 	wiringPlugin := &WiringPlugin{
 		SvcCatEntangler: svccatentangler.SvcCatEntangler{
 			ClusterServiceClassExternalID: clusterServiceClassExternalID,
 			ClusterServicePlanExternalID:  clusterServicePlanExternalID,
 			ResourceType:                  resourceType,
-			OptionalShapes:                optionalShapes,
+			AdditionalShapes:              additionalShapes,
 		},
 		OAPResourceTypeName:        oapResourceTypeName,
 		generateServiceEnvironment: generateServiceEnvironment,

--- a/pkg/orchestration/wiring/aws/resources.go
+++ b/pkg/orchestration/wiring/aws/resources.go
@@ -7,7 +7,6 @@ import (
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringplugin"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil/knownshapes"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil/oap"
-	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil/svccatentangler"
 	"github.com/atlassian/voyager/pkg/servicecatalog"
 )
 
@@ -31,7 +30,7 @@ const (
 	CfnPrefix oap.EnvVarPrefix               = "CF"
 )
 
-func snsSubscribableForSnsV1Template(resource *orch_v1.StateResource, smithResource *smith_v1.Resource, context *wiringplugin.WiringContext) ([]wiringplugin.Shape, error) {
+func snsSubscribableForSnsV1Template(resource *orch_v1.StateResource, smithResource *smith_v1.Resource, _ *wiringplugin.WiringContext) ([]wiringplugin.Shape, error) {
 	templateName, err := oap.TemplateName(resource.Spec)
 	if err != nil {
 		return nil, err
@@ -47,8 +46,8 @@ func snsSubscribableForSnsV1Template(resource *orch_v1.StateResource, smithResou
 // All osb-aws-provider resources are 'almost' the same, differing only in the service/plan names,
 // what they need passed in the ServiceEnvironment.
 var ResourceTypes = map[voyager.ResourceType]wiringplugin.WiringPlugin{
-	DynamoDB: Resource(DynamoDB, DynamoDBName, DynamoDBClass, DynamoDBPlan, dynamoDbServiceEnvironment, DynamoPrefix, svccatentangler.NoOptionalShapes),
-	S3:       Resource(S3, S3Name, S3Class, S3Plan, s3ServiceEnvironment, S3Prefix, svccatentangler.NoOptionalShapes),
+	DynamoDB: Resource(DynamoDB, DynamoDBName, DynamoDBClass, DynamoDBPlan, dynamoDbServiceEnvironment, DynamoPrefix, nil),
+	S3:       Resource(S3, S3Name, S3Class, S3Plan, s3ServiceEnvironment, S3Prefix, nil),
 	Cfn:      Resource(Cfn, CfnName, CfnClass, CfnPlan, CfnServiceEnvironment, CfnPrefix, snsSubscribableForSnsV1Template),
 }
 

--- a/pkg/orchestration/wiring/internaldns/plugin.go
+++ b/pkg/orchestration/wiring/internaldns/plugin.go
@@ -43,12 +43,11 @@ func New() *WiringPlugin {
 			ObjectMeta:                    getObjectMeta,
 			References:                    getReferences,
 			ResourceType:                  ResourceType,
-			OptionalShapes:                svccatentangler.NoOptionalShapes,
 		},
 	}
 }
 
-// can only depend on one kubeIngress
+// getIngressDependency can only depend on one kubeIngress
 func getIngressDependency(dependencies []wiringplugin.WiredDependency) (wiringplugin.WiredDependency, error) {
 	if len(dependencies) == 1 {
 		if dependencies[0].Type == kubeIngressResourceType {

--- a/pkg/orchestration/wiring/postgres/plugin.go
+++ b/pkg/orchestration/wiring/postgres/plugin.go
@@ -68,7 +68,6 @@ func New() *WiringPlugin {
 			ObjectMeta:                    objectMeta,
 			References:                    references,
 			ResourceType:                  ResourceType,
-			OptionalShapes:                svccatentangler.NoOptionalShapes,
 		},
 	}
 }

--- a/pkg/orchestration/wiring/rds/plugin.go
+++ b/pkg/orchestration/wiring/rds/plugin.go
@@ -82,7 +82,6 @@ func New() *WiringPlugin {
 			InstanceSpec:                  instanceSpec,
 			ObjectMeta:                    objectMeta,
 			ResourceType:                  ResourceType,
-			OptionalShapes:                svccatentangler.NoOptionalShapes,
 		},
 	}
 }

--- a/pkg/orchestration/wiring/ups/plugin.go
+++ b/pkg/orchestration/wiring/ups/plugin.go
@@ -25,7 +25,6 @@ func New() *WiringPlugin {
 			ClusterServicePlanExternalID:  clusterServicePlanExternalID,
 			InstanceSpec:                  InstanceSpec,
 			ResourceType:                  ResourceType,
-			OptionalShapes:                svccatentangler.NoOptionalShapes,
 		},
 	}
 }

--- a/pkg/orchestration/wiring/wiringplugin/types.go
+++ b/pkg/orchestration/wiring/wiringplugin/types.go
@@ -18,7 +18,7 @@ type WiringPlugin interface {
 	// WireUp wires up the resource.
 	// Error may be retriable if its an RPC error (like network error). Most errors are not retriable because
 	// this method should be pure/deterministic so if it fails, it fails.
-	WireUp(resource *orch_v1.StateResource, context *WiringContext) (*WiringResult, bool /*retriable*/, error)
+	WireUp(resource *orch_v1.StateResource, context *WiringContext) (result *WiringResult, retriable bool, err error)
 }
 
 // WiringContext contains context information that is passed to an autowiring function to perform autowiring

--- a/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
+++ b/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
@@ -142,7 +142,7 @@ func (e *SvcCatEntangler) constructResourceContract(resource *orch_v1.StateResou
 	if e.AdditionalShapes != nil {
 		additionalShapes, err := e.AdditionalShapes(resource, smithResource, context)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to compute optional shapes for resource %q of type %q", resource.Name, resource.Type)
+			return nil, errors.Wrapf(err, "failed to compute additional shapes for resource %q of type %q", resource.Name, resource.Type)
 		}
 		supportedShapes = append(supportedShapes, additionalShapes...)
 	}

--- a/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
+++ b/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
@@ -3,9 +3,8 @@ package svccatentangler
 import (
 	"encoding/json"
 
-	"github.com/atlassian/voyager"
-
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
+	"github.com/atlassian/voyager"
 	orch_v1 "github.com/atlassian/voyager/pkg/apis/orchestration/v1"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringplugin"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil"

--- a/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
+++ b/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
@@ -3,8 +3,9 @@ package svccatentangler
 import (
 	"encoding/json"
 
-	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/voyager"
+
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	orch_v1 "github.com/atlassian/voyager/pkg/apis/orchestration/v1"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringplugin"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil"
@@ -16,24 +17,43 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-type OptionalShapeFunc func(*orch_v1.StateResource, *smith_v1.Resource, *wiringplugin.WiringContext) ([]wiringplugin.Shape, error)
+// AdditionalShapesFunc is used to return a list of shapes, it is used in the SvcCatEntangler as a way to return a list
+// of shapes for the resource to be used as input to the wiring functions of the dependants. These are additional shapes
+// that will be appended to the default shapes (see core function below).
+//
+// The `resource` is the orchestration level resource that was transformed into `smithResource`.
+type AdditionalShapesFunc func(resource *orch_v1.StateResource, smithResource *smith_v1.Resource, context *wiringplugin.WiringContext) ([]wiringplugin.Shape, error)
 
-func NoOptionalShapes(resource *orch_v1.StateResource, smithResource *smith_v1.Resource, context *wiringplugin.WiringContext) ([]wiringplugin.Shape, error) {
-	return nil, nil
-}
-
+// SvcCatEntagler aims to abstract some of the work involved in writing a WiringPlugin functions. It assumes that every
+// WiringPlugin will provide a bundle spec through InstanceSpec(), the metadata for that spec through ObjectMeta() and a
+// list of smith references through References().
+//
+// This is for WiringPlugins that will create a ServiceInstance.
 type SvcCatEntangler struct {
+
+	// This identifies what resource types can be processed.
+	ResourceType voyager.ResourceType
+
+	// These are the OSB broker class and plan identifiers
 	ClusterServiceClassExternalID servicecatalog.ClassExternalID
 	ClusterServicePlanExternalID  servicecatalog.PlanExternalID
 
+	// InstanceSpec will return the JSON marshaled form of the bundle resource's spec. this
+	// service instance, service binding, deployment, ingress, or other resource.
 	InstanceSpec func(*orch_v1.StateResource, *wiringplugin.WiringContext) ([]byte, error)
-	ObjectMeta   func(*orch_v1.StateResource, *wiringplugin.WiringContext) (meta_v1.ObjectMeta, error)
-	References   func(*orch_v1.StateResource, *wiringplugin.WiringContext) ([]smith_v1.Reference, error)
 
-	ResourceType voyager.ResourceType
+	// ObjectMeta will return the ObjectMeta for the ServiceInstance.
+	// If nil, it's skipped.
+	ObjectMeta func(*orch_v1.StateResource, *wiringplugin.WiringContext) (meta_v1.ObjectMeta, error)
 
-	// optional shapes by resource type
-	OptionalShapes OptionalShapeFunc
+	// References will return a list of Smith references used by the any part of the resulting Smith resource. A Smith
+	// reference looks something like "!{refname}" and require a smith reference entry with the same name to work.
+	// If nil, it's skipped.
+	References func(*orch_v1.StateResource, *wiringplugin.WiringContext) ([]smith_v1.Reference, error)
+
+	// See documentation for AdditionalShapesFunc
+	// If nil, it's skipped.
+	AdditionalShapes AdditionalShapesFunc
 }
 
 type partialSpec struct {
@@ -119,11 +139,13 @@ func (e *SvcCatEntangler) constructResourceContract(resource *orch_v1.StateResou
 	supportedShapes := []wiringplugin.Shape{
 		knownshapes.NewBindableEnvironmentVariables(smithResource.Name, "", nil),
 	}
-	optionalShapes, err := e.OptionalShapes(resource, smithResource, context)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to compute optional shapes for resource %q of type %q", resource.Name, resource.Type)
+	if e.AdditionalShapes != nil {
+		additionalShapes, err := e.AdditionalShapes(resource, smithResource, context)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to compute optional shapes for resource %q of type %q", resource.Name, resource.Type)
+		}
+		supportedShapes = append(supportedShapes, additionalShapes...)
 	}
-	supportedShapes = append(supportedShapes, optionalShapes...)
 	return &wiringplugin.ResourceContract{
 		Shapes: supportedShapes,
 	}, nil


### PR DESCRIPTION
I've added some docs to the SvcCatEntangler. A couple of us took a long time to untangle the entangler and some docs would've helped a lot.

I've also renamed "optional shapes" to "additional shapes". It wasn't clear that it was a function that was adding extra shapes (which in turn implies that there are default shapes). I originally thought it was a way of indicating that these are optional shapes (which is true, but not the entire story).

I've also made `AdditionalShapes` consistent with `References` and `ObjectMeta`, where if any of these are nil they are skipped.

The documentation is also made by looking at the code and asking a few quick questions of @nilebox ; so I'm not sure if each bit of documentation is 100% accurate.