### PR TITLE
Make OSB wiring easier to read

### DIFF
--- a/pkg/orchestration/wiring/postgres/BUILD.bazel
+++ b/pkg/orchestration/wiring/postgres/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -11,11 +11,18 @@ go_library(
         "//pkg/orchestration/wiring/wiringplugin:go_default_library",
         "//pkg/orchestration/wiring/wiringutil:go_default_library",
         "//pkg/orchestration/wiring/wiringutil/knownshapes:go_default_library",
-        "//pkg/orchestration/wiring/wiringutil/svccatentangler:go_default_library",
+        "//pkg/orchestration/wiring/wiringutil/osb:go_default_library",
         "//vendor/github.com/atlassian/smith:go_default_library",
         "//vendor/github.com/atlassian/smith/pkg/apis/smith/v1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["plugin_test.go"],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = ["//pkg/orchestration/wiring/wiringplugin:go_default_library"],
 )

--- a/pkg/orchestration/wiring/postgres/plugin_test.go
+++ b/pkg/orchestration/wiring/postgres/plugin_test.go
@@ -1,0 +1,5 @@
+package postgres
+
+import "github.com/atlassian/voyager/pkg/orchestration/wiring/wiringplugin"
+
+var _ wiringplugin.WiringPlugin = &WiringPlugin{}

--- a/pkg/orchestration/wiring/wiringutil/osb/BUILD.bazel
+++ b/pkg/orchestration/wiring/wiringutil/osb/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["service_instance_wiring.go"],
+    importpath = "github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil/osb",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/orchestration/v1:go_default_library",
+        "//pkg/orchestration/wiring/wiringutil:go_default_library",
+        "//pkg/servicecatalog:go_default_library",
+        "//vendor/github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["service_instance_wiring_test.go"],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)

--- a/pkg/orchestration/wiring/wiringutil/osb/service_instance_wiring.go
+++ b/pkg/orchestration/wiring/wiringutil/osb/service_instance_wiring.go
@@ -1,0 +1,57 @@
+package osb
+
+import (
+	"encoding/json"
+
+	orch_v1 "github.com/atlassian/voyager/pkg/apis/orchestration/v1"
+	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil"
+	"github.com/atlassian/voyager/pkg/servicecatalog"
+	sc_v1b1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"github.com/pkg/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type partialSpec struct {
+	InstanceID string `json:"instanceId"`
+}
+
+// Gets instanceId from resource's spec if present or "" otherwise
+// If the spec is empty or does not contain instance ID, then this returns the empty string.
+func instanceID(resourceSpec *runtime.RawExtension) (string, error) {
+	if resourceSpec == nil {
+		return "", nil
+	}
+
+	spec := partialSpec{}
+	err := json.Unmarshal(resourceSpec.Raw, &spec)
+	if err != nil {
+		return "", errors.Wrap(err, "unmarshalling StateResource spec failed")
+	}
+
+	return spec.InstanceID, nil
+}
+
+func ConstructServiceInstance(resource *orch_v1.StateResource, classID servicecatalog.ClassExternalID, planID servicecatalog.PlanExternalID) (*sc_v1b1.ServiceInstance, error) {
+	serviceInstanceExternalID, err := instanceID(resource.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sc_v1b1.ServiceInstance{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       "ServiceInstance",
+			APIVersion: sc_v1b1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: wiringutil.ServiceInstanceMetaName(resource.Name),
+		},
+		Spec: sc_v1b1.ServiceInstanceSpec{
+			PlanReference: sc_v1b1.PlanReference{
+				ClusterServiceClassExternalID: string(classID),
+				ClusterServicePlanExternalID:  string(planID),
+			},
+			ExternalID: serviceInstanceExternalID,
+		},
+	}, nil
+}

--- a/pkg/orchestration/wiring/wiringutil/osb/service_instance_wiring_test.go
+++ b/pkg/orchestration/wiring/wiringutil/osb/service_instance_wiring_test.go
@@ -1,0 +1,22 @@
+package osb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestInstanceId(t *testing.T) {
+	t.Parallel()
+
+	expected := "washere"
+	actual, err := instanceID(
+		&runtime.RawExtension{
+			Raw: []byte(`{"instanceId":"` + expected + `"}`),
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Implemented a set of lighter OSB helper functions as an alternative to `SvcCatEntangler`, which IMO makes reading the code confusing due to 4 callback functions (it's hard to understand what each of these functions do unless you read the code in `SvcCatEntangler`).

Migrated `Postgres` resource on the new OSB helper code to demonstrate the difference.