### PR TITLE
Remove postgres plugin tests; covered by registry

### DIFF
--- a/pkg/orchestration/wiring/postgres/BUILD.bazel
+++ b/pkg/orchestration/wiring/postgres/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -17,12 +17,4 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["plugin_test.go"],
-    embed = [":go_default_library"],
-    race = "on",
-    deps = ["//pkg/orchestration/wiring/wiringplugin:go_default_library"],
 )

--- a/pkg/orchestration/wiring/postgres/plugin_test.go
+++ b/pkg/orchestration/wiring/postgres/plugin_test.go
@@ -1,5 +1,0 @@
-package postgres
-
-import "github.com/atlassian/voyager/pkg/orchestration/wiring/wiringplugin"
-
-var _ wiringplugin.WiringPlugin = &WiringPlugin{}


### PR DESCRIPTION
This test was broken, it's a compile test that is covered by the wiring/registry/registry.go. Therefore, I removed it.