### PR TITLE
Don't retry if service is not found in Service Central

### DIFF
--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -135,7 +135,11 @@ func (c *Controller) Process(ctx *ctrl.ProcessContext) (bool /* retriable */, er
 	ctx.Logger.Sugar().Infof("Looking up service data for service %q from Service Central", serviceName)
 	serviceData, err := c.getServiceData(auth.NoUser(), serviceName)
 	if err != nil {
-		// should be able to retry SC errors
+		if servicecentral.IsNotFound(err) {
+			// no retries if SC is missing a service record
+			return false, err
+		}
+		// should be able to retry other SC errors
 		return true, err
 	}
 


### PR DESCRIPTION
Our monitor job is failing from time to time due to delay of creation of a ConfigMap in the namespace.
This is likely caused by exceeding the k8s client QPS (`5` QPS, `7` burst), or some other throughput issue.

By looking at the log stats, the peak of queue processing (around 110 items per minute) is caused by missing services in Service Central which are being rate limited instead of dropping off, so each broken service is processed ~15 times during that peak.

The monitor issue is aligned with the timing:
1. Error in monitor log, `11:38:14`
```
{"level":"error","time":"2019-02-04T11:38:14Z","msg":"could not get ServiceInstance \"ups\": serviceinstances.servicecatalog.k8s.io \"ups\" not found","rawmsg":"serviceinstances.servicecatalog.k8s.io \"ups\" not found\ncould not get ServiceInstance \"ups\"\nstash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/pkg/monitor.(*Monitor).verifyUpsServiceInstance\n\tvendor/github.com/atlassian/voyager/pkg/monitor/monitor.go:95\nstash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/pkg/monitor.(*Monitor).Run\n\tvendor/github.com/atlassian/voyager/pkg/monitor/monitor.go:82\nstash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/cmd/monitor/app.(*App).Run\n\tvendor/github.com/atlassian/voyager/cmd/monitor/app/app.go:93\nstash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/cmd/monitor/app.runWithContext\n\tvendor/github.com/atlassian/voyager/cmd/monitor/app/main.go:27\nstash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/cmd.RunInterruptably\n\tvendor/github.com/atlassian/voyager/cmd/common.go:26\nstash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/cmd/monitor/app.Main\n\tvendor/github.com/atlassian/voyager/cmd/monitor/app/main.go:18\nmain.main\n\tcmd/monitor/main.go:8\nruntime.main\n\tGOROOT/src/runtime/proc.go:201\nruntime.goexit\n\tbazel-out/k8-fastbuild/bin/external/io_bazel_rules_go/linux_amd64_pure_stripped/stdlib%/src/runtime/asm_amd64.s:1333"}
```
2. "Started syncing" events (queue items per minute)
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/6176360/52209478-2e849a80-28d8-11e9-9aec-7c5ee4457a33.png">

3. ""Error syncing object" events (items per minute, all of them are caused by "service X was not found"
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/6176360/52209532-5bd14880-28d8-11e9-8b81-cb31e1e4f88a.png">
