### PR TITLE
VYGR-411: Use a simple cache for Service Central

### DIFF
--- a/cmd/synchronization/app/controller_constructor.go
+++ b/cmd/synchronization/app/controller_constructor.go
@@ -4,6 +4,8 @@ import (
 	"github.com/atlassian/ctrl"
 	"github.com/atlassian/smith/pkg/specchecker"
 	"github.com/atlassian/smith/pkg/store"
+	"github.com/atlassian/voyager"
+	creator_v1 "github.com/atlassian/voyager/pkg/apis/creator/v1"
 	comp_v1_client "github.com/atlassian/voyager/pkg/composition/client"
 	"github.com/atlassian/voyager/pkg/k8s"
 	"github.com/atlassian/voyager/pkg/k8s/updater"
@@ -144,6 +146,8 @@ func (cc *ControllerConstructor) New(config *ctrl.Config, cctx *ctrl.Context) (*
 		AccessUpdateErrorCounter:       accessUpdateErrorCounter,
 
 		AllowMutateServices: opts.AllowMutateServices,
+
+		ServiceCache: make(map[voyager.ServiceName]*creator_v1.Service),
 	}
 
 	return &ctrl.Constructed{

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -458,7 +458,7 @@ func (c *Controller) createOrUpdateServiceMetadata(logger *zap.Logger, ns *core_
 	return false, nil
 }
 
-func (c *Controller) getCachedServiceData(name voyager.ServiceName) (*creator_v1.Service /* ok */, bool) {
+func (c *Controller) getCachedServiceData(name voyager.ServiceName) (*creator_v1.Service, bool /* ok */) {
 	serviceCacheMutex.RLock()
 	defer serviceCacheMutex.RUnlock()
 

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -142,8 +142,12 @@ func (c *Controller) Process(ctx *ctrl.ProcessContext) (bool /* retriable */, er
 	ctx.Logger.Sugar().Infof("Looking up service data for service %q from Service Central", serviceName)
 	serviceData, ok := c.getCachedServiceData(serviceName)
 	if !ok {
-		// no retries if SC is missing a service record
+		// no retries if service is missing in cache
 		return false, errors.New("service not found in cache")
+	}
+	if serviceData == serviceTombstone {
+		// no retries if service is missing in SC
+		return false, errors.New("service does not exist in Service Central")
 	}
 
 	operations := []func() (bool, error){

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -69,6 +69,7 @@ const (
 var (
 	// in-memory cache of service records from Service Central
 	serviceCache map[voyager.ServiceName]*creator_v1.Service
+	serviceCacheMutex sync.Mutex
 )
 
 type ServiceMetadataStore interface {
@@ -462,6 +463,8 @@ func (c *Controller) createOrUpdateServiceMetadata(logger *zap.Logger, ns *core_
 }
 
 func (c *Controller) getServiceData(user auth.OptionalUser, name voyager.ServiceName, allowCached bool) (*creator_v1.Service, error) {
+	serviceCacheMutex.Lock()
+	defer serviceCacheMutex.Unlock()
 	if allowCached {
 		service, ok := serviceCache[name]
 		if ok {

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -464,10 +464,13 @@ func (c *Controller) getCachedServiceData(name voyager.ServiceName) (*creator_v1
 }
 
 func (c *Controller) fetchAndCacheServiceData(name voyager.ServiceName) (*creator_v1.Service, error) {
+	service, err := c.fetchServiceData(name)
+
+	// setting lock after a call to SC, so that the HTTP requests are
+	// still parallelized
 	c.ServiceCacheMutex.Lock()
 	defer c.ServiceCacheMutex.Unlock()
 
-	service, err := c.fetchServiceData(name)
 	if err != nil {
 		if servicecentral.IsNotFound(err) {
 			delete(c.ServiceCache, name)

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -68,8 +68,8 @@ const (
 
 var (
 	// in-memory cache of service records from Service Central
-	serviceCache map[voyager.ServiceName]*creator_v1.Service
-	serviceTombstone = &creator_v1.Service{}
+	serviceCache      map[voyager.ServiceName]*creator_v1.Service
+	serviceTombstone  = &creator_v1.Service{}
 	serviceCacheMutex sync.RWMutex
 )
 
@@ -459,7 +459,7 @@ func (c *Controller) createOrUpdateServiceMetadata(logger *zap.Logger, ns *core_
 	return false, nil
 }
 
-func (c *Controller) getCachedServiceData(name voyager.ServiceName) (*creator_v1.Service, /* ok */ bool) {
+func (c *Controller) getCachedServiceData(name voyager.ServiceName) (*creator_v1.Service /* ok */, bool) {
 	serviceCacheMutex.RLock()
 	defer serviceCacheMutex.RUnlock()
 

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -338,7 +338,7 @@ func (c *Controller) syncServiceMetadata() {
 			for service := range svcChan {
 				// Service Central actually doesn't include misc data so we need to perform
 				// additional query to fill out the miscdata for our builds
-				fullService, err := c.ServiceCentral.GetService(context.Background(), auth.NoUser(), servicecentral.ServiceName(service.Name))
+				fullService, err := c.getServiceData(auth.NoUser(), voyager.ServiceName(service.Name))
 				if err != nil {
 					c.Logger.With(zap.Error(err)).Sugar().Errorf("Error getting full service info for %q", service.Name)
 					continue

--- a/pkg/synchronization/controller.go
+++ b/pkg/synchronization/controller.go
@@ -68,7 +68,7 @@ const (
 
 var (
 	// in-memory cache of service records from Service Central
-	serviceCache      map[voyager.ServiceName]*creator_v1.Service
+	serviceCache      = make(map[voyager.ServiceName]*creator_v1.Service)
 	serviceTombstone  = &creator_v1.Service{}
 	serviceCacheMutex sync.RWMutex
 )

--- a/pkg/synchronization/controller_test.go
+++ b/pkg/synchronization/controller_test.go
@@ -174,7 +174,7 @@ func TestCreatesConfigMapFromServiceCentralData(t *testing.T) {
 			expected := basicServiceProperties(service, voyager.EnvTypeDev)
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -285,7 +285,7 @@ func TestIncludesPagerDutyForClusterEnvironment(t *testing.T) {
 
 					tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-					_, err = cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+					_, err = cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 					require.NoError(t, err)
 
 					// make sure the controller knows we are our specific environment type
@@ -349,7 +349,7 @@ func TestReturnsErrorWhenPagerDutyNotPresent(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			// we have not set pagerduty for this environment
@@ -398,7 +398,7 @@ func TestReturnsErrorWhenPagerDutyEmptyForEnvironment(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			// we have not set pagerduty for this environment
@@ -485,7 +485,7 @@ func TestUpdatesExistingConfigMap(t *testing.T) {
 			expected := basicServiceProperties(service, voyager.EnvTypeDev)
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -595,7 +595,7 @@ func TestSkipsConfigMapUpdateWhenMetadataIsTheSame(t *testing.T) {
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(existingService, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -643,7 +643,7 @@ func TestMarksRetriableWhenNotKnownService(t *testing.T) {
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(&creator_v1.Service{}, errors.Errorf("Could not find service"))
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.Error(t, err)
 
 			retriable, err := cntrlr.Process(ctx)
@@ -813,7 +813,7 @@ func TestCreatesDockerSecret(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -902,7 +902,7 @@ func TestUpdatesDockerSecret(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -958,7 +958,7 @@ func TestDockerSecretNonExistent(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -1007,7 +1007,7 @@ func TestDockerSecretIncorrectType(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -1059,7 +1059,7 @@ func TestAddsKube2IamAnnotation(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -1124,7 +1124,7 @@ func TestCreatesCommonSecret(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -1215,7 +1215,7 @@ func TestHandlesExistingCommonSecret(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -1272,7 +1272,7 @@ func TestUpdatesKube2IamAnnotation(t *testing.T) {
 			}
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.fetchAndCacheServiceData(auth.NoUser(), voyager.ServiceName(serviceNameSc))
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
 			require.NoError(t, err)
 
 			_, err = cntrlr.Process(ctx)
@@ -1474,6 +1474,8 @@ func (tc *testCase) newController(t *testing.T, mainClient *k8s_fake.Clientset, 
 		AccessUpdateErrorCounter:       auec,
 
 		AllowMutateServices: true,
+
+		ServiceCache: make(map[voyager.ServiceName]*creator_v1.Service),
 	}
 
 	pctx := &ctrl.ProcessContext{

--- a/pkg/synchronization/roles_test.go
+++ b/pkg/synchronization/roles_test.go
@@ -57,7 +57,10 @@ func TestCreatesRoleBindingsFromServiceCentralData(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
+			require.NoError(t, err)
+
+			_, err = cntrlr.Process(ctx)
 			require.NoError(t, err)
 
 			actions := tc.mainFake.Actions()
@@ -180,7 +183,10 @@ func TestSkipsUpdateOfRoleBindingsIfNoChange(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
+			require.NoError(t, err)
+
+			_, err = cntrlr.Process(ctx)
 			require.NoError(t, err)
 
 			actions := tc.mainFake.Actions()
@@ -229,7 +235,10 @@ func TestEmptyBuildRoleBindingsWhenListsEmpty(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
+			require.NoError(t, err)
+
+			_, err = cntrlr.Process(ctx)
 			require.NoError(t, err)
 
 			actions := tc.mainFake.Actions()
@@ -278,7 +287,10 @@ func TestEmptyRoleBindingsNonExistantBuilds(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			_, err := cntrlr.fetchAndCacheServiceData(voyager.ServiceName(serviceNameSc))
+			require.NoError(t, err)
+
+			_, err = cntrlr.Process(ctx)
 			require.NoError(t, err)
 
 			actions := tc.mainFake.Actions()


### PR DESCRIPTION
This is a simple implementation of a cache which should reduce the number of requests sent to Service Central without changing the actual logic.