### PR TITLE
MICROSHELP-5236: [DO NOT MERGE] Check the service does not exist before creating

### DIFF
--- a/pkg/creator/BUILD.bazel
+++ b/pkg/creator/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//vendor/go.uber.org/zap:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
     ],


### PR DESCRIPTION
Currently we error out because of something like:
```
ERROR: failed to create service: Internal error occurred: Failed to update PagerDuty metadata in Service Central: BadRequest: failed to update service "sgreenup-test-1". Response: {
  "data": [],
  "message": "Cannot update owner/admins of service sgreenup-test-1 when SSAM container is set. Please update owner/admins using SSAM",
  "meta": null,
  "status_code": 400
}
ERROR: For assistance, try: atlas service --help
```

But this is not clear that the service already exists and that is why there is an error. I've added a check for an existing service.