### PR TITLE
VYGR-308 prevent user error from bubbling up to ctrl (part 1)

### DIFF
--- a/pkg/orchestration/controller.go
+++ b/pkg/orchestration/controller.go
@@ -48,7 +48,7 @@ func ByConfigMapNameIndexKey(namespace string, configMapName string) string {
 
 type Entangler interface {
 	Entangle(*orch_v1.State, *wiring.EntangleContext) wiring.EntangleResult
-	Status(*orch_v1.StateResource, *wiring.StatusContext) wiring.EntangleStatusResult
+	Status(*orch_v1.StateResource, *wiring.StatusContext) wiring.StatusResult
 }
 
 type Controller struct {
@@ -336,9 +336,9 @@ func (c *Controller) calculateResourceStatuses(stateResources []orch_v1.StateRes
 
 		result := c.Entangler.Status(&stateRes, prepareStatusContext(stateRes.Name, bundle))
 		switch r := result.(type) {
-		case *wiring.EntangleStatusResultSuccess:
+		case *wiring.StatusResultSuccess:
 			status.ResourceStatusData = r.ResourceStatusData
-		case *wiring.EntangleStatusResultFailure:
+		case *wiring.StatusResultFailure:
 			// External Errors are not special - all errors are just placed into the status
 			status.ResourceStatusData = orch_v1.ResourceStatusData{
 				Conditions: []cond_v1.Condition{

--- a/pkg/orchestration/controller.go
+++ b/pkg/orchestration/controller.go
@@ -130,7 +130,7 @@ func (c *Controller) process(logger *zap.Logger, state *orch_v1.State) (*smith_v
 		return nil, external, false, retriable, err
 	}
 
-	conflict, retriable, bundle, err = c.createOrUpdateBundle(logger, state, bundle)
+	conflict, retriable, bundle, err := c.createOrUpdateBundle(logger, state, bundle)
 	return bundle, false, conflict, retriable, err
 
 }

--- a/pkg/orchestration/wiring/aws/resources.go
+++ b/pkg/orchestration/wiring/aws/resources.go
@@ -35,9 +35,9 @@ const (
 // All osb-aws-provider resources are 'almost' the same, differing only in the service/plan names,
 // what they need passed in the ServiceEnvironment.
 var ResourceTypes = map[voyager.ResourceType]wiringplugin.WiringPlugin{
-	DynamoDB: wiringutil.StatusAdapter(Resource(DynamoDB, DynamoDBName, DynamoDBClass, DynamoDBPlan, dynamoDbServiceEnvironment, dynamoDbShapes).WireUp),
-	S3:       wiringutil.StatusAdapter(Resource(S3, S3Name, S3Class, S3Plan, s3ServiceEnvironment, s3Shapes).WireUp),
-	Cfn:      wiringutil.StatusAdapter(Resource(Cfn, CfnName, CfnClass, CfnPlan, CfnServiceEnvironment, cfnShapes).WireUp),
+	DynamoDB: wiringutil.TemporaryNewWiringMigrationAdapter(Resource(DynamoDB, DynamoDBName, DynamoDBClass, DynamoDBPlan, dynamoDbServiceEnvironment, dynamoDbShapes).WireUp),
+	S3:       wiringutil.TemporaryNewWiringMigrationAdapter(Resource(S3, S3Name, S3Class, S3Plan, s3ServiceEnvironment, s3Shapes).WireUp),
+	Cfn:      wiringutil.TemporaryNewWiringMigrationAdapter(Resource(Cfn, CfnName, CfnClass, CfnPlan, CfnServiceEnvironment, cfnShapes).WireUp),
 }
 
 func cfnShapes(resource *orch_v1.StateResource, smithResource *smith_v1.Resource, _ *wiringplugin.WiringContext) ([]wiringplugin.Shape, error) {

--- a/pkg/orchestration/wiring/ec2compute/common/common.go
+++ b/pkg/orchestration/wiring/ec2compute/common/common.go
@@ -99,7 +99,7 @@ func constructComputeSpec(spec *runtime.RawExtension) (StateComputeSpec, error) 
 	return computeSpec, err
 }
 
-func WireUp(microServiceNameInSpec, ec2ComputePlanName string, stateResource *orch_v1.StateResource, context *wiringplugin.WiringContext, constructComputeParameters ConstructComputeParametersFunction) (*wiringplugin.WiringResult, bool, error) {
+func WireUp(microServiceNameInSpec, ec2ComputePlanName string, stateResource *orch_v1.StateResource, context *wiringplugin.WiringContext, constructComputeParameters ConstructComputeParametersFunction) (*wiringplugin.WiringResultSuccess, bool, error) {
 	dependencies := context.Dependencies
 
 	if err := compute.ValidateASAPDependencies(context); err != nil {
@@ -253,7 +253,7 @@ func WireUp(microServiceNameInSpec, ec2ComputePlanName string, stateResource *or
 	// Wire Result
 	smithResources := append(bindingResources, iamPluginInstanceSmithResource, iamPluginBindingSmithResource, computeResource)
 
-	result := &wiringplugin.WiringResult{
+	result := &wiringplugin.WiringResultSuccess{
 		Resources: smithResources,
 	}
 

--- a/pkg/orchestration/wiring/ec2compute/v2/plugin.go
+++ b/pkg/orchestration/wiring/ec2compute/v2/plugin.go
@@ -153,7 +153,7 @@ func constructComputeParameters(origSpec *runtime.RawExtension, iamRoleRef, iamI
 	return util.ToRawExtension(finalSpec)
 }
 
-func WireUp(stateResource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResult, bool, error) {
+func WireUp(stateResource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResultSuccess, bool, error) {
 	if stateResource.Type != ResourceType {
 		return nil, false, errors.Errorf("invalid resource type: %q", stateResource.Type)
 	}

--- a/pkg/orchestration/wiring/entangler.go
+++ b/pkg/orchestration/wiring/entangler.go
@@ -77,15 +77,73 @@ type Entangler struct {
 }
 
 type wiredStateResource struct {
-	Name         voyager.ResourceName
-	Type         voyager.ResourceType
-	WiringResult wiringplugin.WiringResult
+	Name      voyager.ResourceName
+	Type      voyager.ResourceType
+	Contract  wiringplugin.ResourceContract
+	Resources []smith_v1.Resource
 }
 
-func (en *Entangler) Entangle(state *orch_v1.State, context *EntangleContext) (*smith_v1.Bundle, bool /*retriable*/, error) {
+type EntangleResultType string
+type EntangleStatusResultType string
+
+const (
+	EntangleResultSuccessType       EntangleResultType       = "success"
+	EntangleResultFailureType       EntangleResultType       = "failure"
+	EntangleStatusResultSuccessType EntangleStatusResultType = "success"
+	EntangleStatusResultFailureType EntangleStatusResultType = "failure"
+)
+
+type EntangleResult interface {
+	StatusType() EntangleResultType
+}
+
+type EntangleResultSuccess struct {
+	Bundle *smith_v1.Bundle
+}
+
+func (e *EntangleResultSuccess) StatusType() EntangleResultType {
+	return EntangleResultSuccessType
+}
+
+type EntangleResultFailure struct {
+	Error            error
+	IsRetriableError bool
+	IsExternalError  bool
+}
+
+func (e *EntangleResultFailure) StatusType() EntangleResultType {
+	return EntangleResultFailureType
+}
+
+type EntangleStatusResult interface {
+	StatusType() EntangleStatusResultType
+}
+
+type EntangleStatusResultSuccess struct {
+	ResourceStatusData orch_v1.ResourceStatusData
+}
+
+func (e *EntangleStatusResultSuccess) StatusType() EntangleStatusResultType {
+	return EntangleStatusResultSuccessType
+}
+
+type EntangleStatusResultFailure struct {
+	Error           error
+	IsExternalError bool
+}
+
+func (e *EntangleStatusResultFailure) StatusType() EntangleStatusResultType {
+	return EntangleStatusResultFailureType
+}
+
+func (en *Entangler) Entangle(state *orch_v1.State, context *EntangleContext) EntangleResult {
 	g, sorted, err := sortStateResources(state.Spec.Resources)
 	if err != nil {
-		return nil, false, err
+		// failures here are caused by a cycle or invalid dependency specified by the user
+		return &EntangleResultFailure{
+			Error:           err,
+			IsExternalError: true,
+		}
 	}
 
 	w := worker{
@@ -103,11 +161,15 @@ func (en *Entangler) Entangle(state *orch_v1.State, context *EntangleContext) (*
 	// Atlassian Specific Things
 	legacyConfigFunc := en.GetLegacyConfigFunc
 	if legacyConfigFunc == nil {
-		return nil, false, errors.New("missing legacy config")
+		return &EntangleResultFailure{
+			Error: errors.New("missing legacy config"),
+		}
 	}
 	legacyConfig := legacyConfigFunc(location)
 	if legacyConfig == nil {
-		return nil, false, errors.Errorf("no legacy config for %s", location)
+		return &EntangleResultFailure{
+			Error: errors.Errorf("no legacy config for %s", location),
+		}
 	}
 
 	tags := make(map[voyager.Tag]string)
@@ -135,14 +197,20 @@ func (en *Entangler) Entangle(state *orch_v1.State, context *EntangleContext) (*
 	for _, v := range sorted {
 		resource := g.Vertices[v].Data.(*orch_v1.StateResource)
 		dependants := getDependants(resource.Name, g.Vertices[v].IncomingEdges, state.Spec.Resources)
-		retriable, entErr := w.entangle(resource, &state.ObjectMeta, &stateContext, dependants)
+		external, retriable, entErr := w.entangle(resource, &state.ObjectMeta, &stateContext, dependants)
 		if entErr != nil {
-			return nil, retriable, errors.Wrapf(entErr, "failed to wire up resource %q of type %q", resource.Name, resource.Type)
+			return &EntangleResultFailure{
+				Error:            errors.Wrapf(entErr, "failed to wire up resource %q of type %q", resource.Name, resource.Type),
+				IsRetriableError: retriable,
+				IsExternalError:  external,
+			}
 		}
 	}
 	processedResources, err := postProcessResources(w.allWiredResourcesList)
 	if err != nil {
-		return nil, false, err
+		return &EntangleResultFailure{
+			Error: err,
+		}
 	}
 	trueVar := true
 	bundle := &smith_v1.Bundle{
@@ -169,13 +237,20 @@ func (en *Entangler) Entangle(state *orch_v1.State, context *EntangleContext) (*
 		},
 	}
 
-	return bundle, false, nil
+	return &EntangleResultSuccess{
+		Bundle: bundle,
+	}
 }
 
-func (en *Entangler) Status(resource *orch_v1.StateResource, context *StatusContext) (orch_v1.ResourceStatusData, bool /*retriable*/, error) {
+func (en *Entangler) Status(resource *orch_v1.StateResource, context *StatusContext) EntangleStatusResult {
 	plugin, ok := en.Plugins[resource.Type]
 	if !ok {
-		return orch_v1.ResourceStatusData{}, false, errors.New("unknown resource type")
+		// The plugin not existing is an external issue, the service descriptor contains
+		// an invalid resource type.
+		return &EntangleStatusResultFailure{
+			Error:           errors.New("unknown resource type"),
+			IsExternalError: true,
+		}
 	}
 	// We don't want to expose types from plugins to the entangler consumer so that they are decoupled.
 	bundleResources := make([]wiringplugin.BundleResource, 0, len(context.BundleResources))
@@ -185,14 +260,25 @@ func (en *Entangler) Status(resource *orch_v1.StateResource, context *StatusCont
 			Status:   res.Status,
 		})
 	}
-	result, retriable, err := plugin.Status(resource, &wiringplugin.StatusContext{
+	result := plugin.Status(resource, &wiringplugin.StatusContext{
 		BundleResources: bundleResources,
 		PluginStatuses:  context.PluginStatuses,
 	})
-	if err != nil {
-		return orch_v1.ResourceStatusData{}, retriable, errors.Wrap(err, "error invoking autowiring plugin")
+	switch r := result.(type) {
+	case *wiringplugin.StatusResultSuccess:
+		return &EntangleStatusResultSuccess{
+			ResourceStatusData: r.ResourceStatusData,
+		}
+	case *wiringplugin.StatusResultFailure:
+		return &EntangleStatusResultFailure{
+			Error:           errors.Wrap(r.Error, "error invoking autowiring plugin"),
+			IsExternalError: r.IsExternalError,
+		}
+	default:
+		return &EntangleStatusResultFailure{
+			Error: errors.Errorf("unknown status result type %q", r.StatusType()),
+		}
 	}
-	return result.ResourceStatusData, false, nil
 }
 
 // postProcessResources converts resources to Unstructured and cleans up some fields:
@@ -239,13 +325,13 @@ type worker struct {
 	allWiredResourcesList []smith_v1.Resource
 }
 
-func (w *worker) entangle(resource *orch_v1.StateResource, stateMeta *meta_v1.ObjectMeta, context *wiringplugin.StateContext, dependants []wiringplugin.DependantResource) (bool /*retriable*/, error) {
+func (w *worker) entangle(resource *orch_v1.StateResource, stateMeta *meta_v1.ObjectMeta, context *wiringplugin.StateContext, dependants []wiringplugin.DependantResource) (bool /* external */, bool /*retriable*/, error) {
 	if w.allWiredResources[resource.Name] != nil {
-		return false, errors.New("resource with same name already exists")
+		return true, false, errors.New("resource with same name already exists")
 	}
 	plugin := w.plugins[resource.Type]
 	if plugin == nil {
-		return false, errors.New("no plugin for resources type is registered")
+		return true, false, errors.New("no plugin for resources type is registered")
 	}
 	deps := make([]wiringplugin.WiredDependency, 0, len(resource.DependsOn))
 	for _, dep := range resource.DependsOn {
@@ -253,11 +339,11 @@ func (w *worker) entangle(resource *orch_v1.StateResource, stateMeta *meta_v1.Ob
 		if res == nil {
 			// This can only happen if there is a bug! Dependency on a missing resource should have been detected by
 			// the topological sort.
-			return false, errors.Errorf("resource %q of type %q has a dependency that has not been wired yet: %q", resource.Name, resource.Type, dep)
+			return false, false, errors.Errorf("resource %q of type %q has a dependency that has not been wired yet: %q", resource.Name, resource.Type, dep)
 		}
 		deps = append(deps, wiringplugin.WiredDependency{
 			Name:       res.Name,
-			Contract:   res.WiringResult.Contract,
+			Contract:   res.Contract,
 			Attributes: dep.Attributes,
 		})
 	}
@@ -267,32 +353,39 @@ func (w *worker) entangle(resource *orch_v1.StateResource, stateMeta *meta_v1.Ob
 		Dependants:   dependants,
 	}
 	stateMeta.DeepCopyInto(&wiringContext.StateMeta)
-	result, retriable, err := plugin.WireUp(resource, wiringContext)
-	if err != nil {
-		return retriable, errors.Wrap(err, "error invoking plugin")
-	}
+	result := plugin.WireUp(resource, wiringContext)
+	switch r := result.(type) {
+	case *wiringplugin.WiringResultSuccess:
+		// Sanity check plugin output
+		// If the plugin itself is returning garbage we consider it an internal error
+		err := w.validateWireUp(resource, r)
+		if err != nil {
+			return false, false, err
+		}
 
-	retriable, err = w.validateWireUp(resource, result)
-	if err != nil {
-		return retriable, err
-	}
+		w.allWiredResources[resource.Name] = &wiredStateResource{
+			Name:      resource.Name,
+			Type:      resource.Type,
+			Resources: r.Resources,
+			Contract:  r.Contract,
+		}
+		w.allWiredResourcesList = append(w.allWiredResourcesList, r.Resources...)
+		return false, false, nil
 
-	w.allWiredResources[resource.Name] = &wiredStateResource{
-		Name:         resource.Name,
-		Type:         resource.Type,
-		WiringResult: *result,
+	case *wiringplugin.WiringResultFailure:
+		return r.IsExternalError, r.IsRetriableError, errors.Wrap(r.Error, "error invoking plugin")
+	default:
+		return false, false, errors.Errorf("unexpected wiring result status type %q", r.StatusType())
 	}
-	w.allWiredResourcesList = append(w.allWiredResourcesList, result.Resources...)
-	return false, nil
 }
 
-func (w *worker) validateWireUp(resource *orch_v1.StateResource, result *wiringplugin.WiringResult) (bool, error) {
+func (w *worker) validateWireUp(resource *orch_v1.StateResource, result *wiringplugin.WiringResultSuccess) error {
 	if shapeNames := findDuplicateShapeNames(result.Contract.Shapes); len(shapeNames) != 0 {
-		return false, errors.Errorf("internal error in wiring plugin - duplicate shapes received from plugin: %s",
+		return errors.Errorf("internal error in wiring plugin - duplicate shapes received from plugin: %s",
 			strings.Join(shapeNames, ", "))
 	}
 
-	return false, validateResources(resource, result.Resources)
+	return validateResources(resource, result.Resources)
 }
 
 func sortStateResourcesInternal(g *graph.Graph, stateResources []orch_v1.StateResource) ([]graph.V, error) {

--- a/pkg/orchestration/wiring/k8scompute/plugin.go
+++ b/pkg/orchestration/wiring/k8scompute/plugin.go
@@ -99,7 +99,7 @@ func validateScaling(s Scaling) error {
 }
 
 // WireUp is the main autowiring function for the K8SCompute resource, building a native kube deployment and HPA
-func WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResult, bool /*retriable*/, error) {
+func WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResultSuccess, bool /*retriable*/, error) {
 	if resource.Type != apik8scompute.ResourceType {
 		return nil, false, errors.Errorf("invalid resource type: %q", resource.Type)
 	}
@@ -355,7 +355,7 @@ func WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext
 		smithResources = append(smithResources, hpa)
 	}
 
-	result := &wiringplugin.WiringResult{
+	result := &wiringplugin.WiringResultSuccess{
 		Contract: wiringplugin.ResourceContract{
 			Shapes: []wiringplugin.Shape{
 				knownshapes.NewSetOfPodsSelectableByLabels(deployment.Name, labelMap),

--- a/pkg/orchestration/wiring/kubeingress/plugin.go
+++ b/pkg/orchestration/wiring/kubeingress/plugin.go
@@ -44,7 +44,7 @@ const (
 )
 
 // WireUp is the main autowiring function for KubeIngress
-func WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResult, bool /*retriable*/, error) {
+func WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResultSuccess, bool /*retriable*/, error) {
 
 	// Fail if the resource type is wrong
 	if resource.Type != ResourceType {
@@ -65,7 +65,7 @@ func WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext
 		return nil, false, errors.Wrap(err, "failed building ingress resource")
 	}
 
-	result := &wiringplugin.WiringResult{
+	result := &wiringplugin.WiringResultSuccess{
 		Contract: wiringplugin.ResourceContract{
 			Shapes: []wiringplugin.Shape{
 				knownshapes.NewIngressEndpoint(ingressResource.Name),

--- a/pkg/orchestration/wiring/postgres/plugin.go
+++ b/pkg/orchestration/wiring/postgres/plugin.go
@@ -61,7 +61,7 @@ func New() *WiringPlugin {
 	return &WiringPlugin{}
 }
 
-func (p *WiringPlugin) WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResult, bool /*retriable*/, error) {
+func (p *WiringPlugin) WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResultSuccess, bool /*retriable*/, error) {
 	if resource.Type != ResourceType {
 		return nil, false, errors.Errorf("invalid resource type: %q", resource.Type)
 	}
@@ -101,7 +101,7 @@ func (p *WiringPlugin) WireUp(resource *orch_v1.StateResource, context *wiringpl
 		return nil, false, err
 	}
 
-	result := &wiringplugin.WiringResult{
+	result := &wiringplugin.WiringResultSuccess{
 		Contract: wiringplugin.ResourceContract{
 			Shapes: shapes,
 		},

--- a/pkg/orchestration/wiring/registry/registry.go
+++ b/pkg/orchestration/wiring/registry/registry.go
@@ -19,16 +19,16 @@ import (
 )
 
 var KnownWiringPlugins = map[voyager.ResourceType]wiringplugin.WiringPlugin{
-	apik8scompute.ResourceType:  wiringutil.StatusAdapter(k8scompute.WireUp),
-	kubeingress.ResourceType:    wiringutil.StatusAdapter(kubeingress.WireUp),
-	ec2compute_v2.ResourceType:  wiringutil.StatusAdapter(ec2compute_v2.WireUp),
-	ups.ResourceType:            wiringutil.StatusAdapter(ups.New().WireUp),
+	apik8scompute.ResourceType:  wiringutil.TemporaryNewWiringMigrationAdapter(k8scompute.WireUp),
+	kubeingress.ResourceType:    wiringutil.TemporaryNewWiringMigrationAdapter(kubeingress.WireUp),
+	ec2compute_v2.ResourceType:  wiringutil.TemporaryNewWiringMigrationAdapter(ec2compute_v2.WireUp),
+	ups.ResourceType:            wiringutil.TemporaryNewWiringMigrationAdapter(ups.New().WireUp),
 	aws.Cfn:                     aws.ResourceTypes[aws.Cfn],
 	aws.DynamoDB:                aws.ResourceTypes[aws.DynamoDB],
 	aws.S3:                      aws.ResourceTypes[aws.S3],
-	postgres.ResourceType:       wiringutil.StatusAdapter(postgres.New().WireUp),
-	rds.ResourceType:            wiringutil.StatusAdapter(rds.New().WireUp),
-	sqs.ResourceType:            wiringutil.StatusAdapter(sqs.WireUp),
-	asapkey.ResourceType:        wiringutil.StatusAdapter(asapkey.New().WireUp),
-	apiplatformdns.ResourceType: wiringutil.StatusAdapter(platformdns.New().WireUp),
+	postgres.ResourceType:       wiringutil.TemporaryNewWiringMigrationAdapter(postgres.New().WireUp),
+	rds.ResourceType:            wiringutil.TemporaryNewWiringMigrationAdapter(rds.New().WireUp),
+	sqs.ResourceType:            wiringutil.TemporaryNewWiringMigrationAdapter(sqs.WireUp),
+	asapkey.ResourceType:        wiringutil.TemporaryNewWiringMigrationAdapter(asapkey.New().WireUp),
+	apiplatformdns.ResourceType: wiringutil.TemporaryNewWiringMigrationAdapter(platformdns.New().WireUp),
 }

--- a/pkg/orchestration/wiring/sqs/plugin.go
+++ b/pkg/orchestration/wiring/sqs/plugin.go
@@ -43,7 +43,7 @@ type partialSqsAttributes struct {
 // exposing too much. This is a separate function - for the moment - because
 // it needs to understand how to wire the dependencies, which is atypical
 // for aws-osb-provider resources.
-func WireUp(stateResource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResult, bool, error) {
+func WireUp(stateResource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResultSuccess, bool, error) {
 	if stateResource.Type != ResourceType {
 		return nil, false, errors.Errorf("invalid resource type: %q", stateResource.Type)
 	}
@@ -102,7 +102,7 @@ func WireUp(stateResource *orch_v1.StateResource, context *wiringplugin.WiringCo
 		envVars["DEAD_QUEUE_NAME"] = "data.dead-queue-name"
 		envVars["DEAD_QUEUE_ARN"] = "data.dead-queue-arn"
 	}
-	result := &wiringplugin.WiringResult{
+	result := &wiringplugin.WiringResultSuccess{
 		Contract: wiringplugin.ResourceContract{
 			Shapes: []wiringplugin.Shape{
 				knownshapes.NewBindableEnvironmentVariables(serviceInstance.Name, ResourcePrefix, envVars),

--- a/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
+++ b/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
@@ -147,7 +147,7 @@ func (e *SvcCatEntangler) constructResourceContract(resource *orch_v1.StateResou
 	}, nil
 }
 
-func (e *SvcCatEntangler) WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResult, bool, error) {
+func (e *SvcCatEntangler) WireUp(resource *orch_v1.StateResource, context *wiringplugin.WiringContext) (*wiringplugin.WiringResultSuccess, bool, error) {
 	if resource.Type != e.ResourceType {
 		return nil, false, errors.Errorf("invalid resource type: %q", resource.Type)
 	}
@@ -162,7 +162,7 @@ func (e *SvcCatEntangler) WireUp(resource *orch_v1.StateResource, context *wirin
 		return nil, false, err
 	}
 
-	result := &wiringplugin.WiringResult{
+	result := &wiringplugin.WiringResultSuccess{
 		Contract:  *resourceContract,
 		Resources: []smith_v1.Resource{serviceInstance},
 	}


### PR DESCRIPTION
This is the first part of a PR that tries to add some new things into orchestration to distinguish between external and non external errors.