### PR TITLE
VYGR-425: Separate service central types into read and write

### DIFF
--- a/pkg/execution/svccatadmission/external_id_test.go
+++ b/pkg/execution/svccatadmission/external_id_test.go
@@ -101,11 +101,11 @@ func TestExternalUUIDAdmitFunc(t *testing.T) {
 
 			got, err := ExternalUUIDAdmitFunc(ctx, uuidStub, scStore, rpsCache, tc.admissionReview)
 			if (err != nil) != tc.wantErr {
-				t.Fatalf("ExternalUUIDAdmitFunc() error = %v, wantErr %v", err, tc.wantErr)
+				require.Equal(t, tc.wantErr, err)
 			}
 			if got.Allowed != true {
 				if !reflect.DeepEqual(got, tc.want) {
-					t.Fatalf("ExternalUUIDAdmitFunc() = %v, want %v", got, tc.want)
+					require.Equal(t, tc.want, got)
 				}
 			} else {
 				// if it's Allowed, we're attempting a patch with a UUID, which

--- a/pkg/execution/svccatadmission/internaldns.go
+++ b/pkg/execution/svccatadmission/internaldns.go
@@ -80,14 +80,14 @@ func InternalDNSAdmitFunc(ctx context.Context, microsServerClient microsServerCl
 
 	if serviceCentralData == nil {
 		reason := fmt.Sprintf(
-			"namespace service %q does not exist in Service Central - should be impossible",
+			"namespace service %q does not exist in Service Central",
 			serviceName)
 		return &admissionv1beta1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Message: reason,
-				Code:    http.StatusForbidden,
-				Reason:  metav1.StatusReasonForbidden,
+				Code:    http.StatusInternalServerError,
+				Reason:  metav1.StatusReasonInternalError,
 			},
 		}, nil
 	}

--- a/pkg/execution/svccatadmission/internaldns.go
+++ b/pkg/execution/svccatadmission/internaldns.go
@@ -78,6 +78,20 @@ func InternalDNSAdmitFunc(ctx context.Context, microsServerClient microsServerCl
 		return nil, errors.Errorf("error fetching service central data for serviceName %q", serviceName)
 	}
 
+	if serviceCentralData == nil {
+		reason := fmt.Sprintf(
+			"namespace service %q does not exist in Service Central - should be impossible",
+			serviceName)
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: reason,
+				Code:    http.StatusForbidden,
+				Reason:  metav1.StatusReasonForbidden,
+			},
+		}, nil
+	}
+
 	// types to store parallel domain owner fetches
 	type domainOwnership struct {
 		requestedDomain         string

--- a/pkg/execution/svccatadmission/internaldns_test.go
+++ b/pkg/execution/svccatadmission/internaldns_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/atlassian/voyager/pkg/k8s"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/platformdns/api"
 	"github.com/atlassian/voyager/pkg/util/logz"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -255,10 +256,10 @@ func TestInternalDNSAdmitFunc(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := InternalDNSAdmitFunc(ctx, microsServerMock, serviceCentralMock, tc.admissionReview)
 			if (err != nil) != tc.wantErr {
-				t.Fatalf("InternalDNSAdmitFunc() error = %v, wantErr %v", err, tc.wantErr)
+				require.Equal(t, tc.wantErr, err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("InternalDNSAdmitFunc() = %v, want %v", got, tc.want)
+				require.Equal(t, tc.want, got)
 			}
 		})
 	}

--- a/pkg/execution/svccatadmission/micros_test.go
+++ b/pkg/execution/svccatadmission/micros_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/atlassian/voyager/pkg/k8s"
+	"github.com/stretchr/testify/require"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -69,11 +70,10 @@ func TestMicrosAdmitFunc(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := MicrosAdmitFunc(ctx, scStore, tc.admissionReview)
 			if (err != nil) != tc.wantErr {
-				t.Errorf("MicrosAdmitFunc() error = %v, wantErr %v", err, tc.wantErr)
-				return
+				require.Equal(t, tc.wantErr, err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("MicrosAdmitFunc() = %v, want %v", got, tc.want)
+				require.Equal(t, tc.want, got)
 			}
 		})
 	}

--- a/pkg/execution/svccatadmission/types.go
+++ b/pkg/execution/svccatadmission/types.go
@@ -9,7 +9,7 @@ import (
 )
 
 type serviceCentralClient interface {
-	ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]servicecentral.ServiceData, error)
+	ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]servicecentral.ServiceDataRead, error)
 }
 
 type microsServerClient interface {

--- a/pkg/execution/svccatadmission/util.go
+++ b/pkg/execution/svccatadmission/util.go
@@ -20,7 +20,7 @@ func getServiceNameFromNamespace(namespace string) voyager.ServiceName {
 	return voyager.ServiceName(strings.Split(namespace, "--")[0])
 }
 
-func getServiceData(ctx context.Context, scClient serviceCentralClient, serviceName voyager.ServiceName) (*servicecentral.ServiceData, error) {
+func getServiceData(ctx context.Context, scClient serviceCentralClient, serviceName voyager.ServiceName) (*servicecentral.ServiceDataRead, error) {
 	search := fmt.Sprintf("service_name='%s'", serviceName)
 	listData, err := scClient.ListServices(ctx, auth.NoUser(), search)
 

--- a/pkg/execution/svccatadmission/util_for_test.go
+++ b/pkg/execution/svccatadmission/util_for_test.go
@@ -37,13 +37,13 @@ type serviceCentralClientMock struct {
 
 var _ serviceCentralClient = &serviceCentralClientMock{}
 
-func (m *serviceCentralClientMock) ListServices(ctx context.Context, user auth.OptionalUser, serviceName string) ([]servicecentral.ServiceData, error) {
+func (m *serviceCentralClientMock) ListServices(ctx context.Context, user auth.OptionalUser, serviceName string) ([]servicecentral.ServiceDataRead, error) {
 	args := m.Called(ctx, user, serviceName)
 	result := args.Get(0)
 	if result == nil {
 		return nil, args.Error(1)
 	}
-	return []servicecentral.ServiceData{result.(servicecentral.ServiceData)}, args.Error(1)
+	return []servicecentral.ServiceDataRead{result.(servicecentral.ServiceDataRead)}, args.Error(1)
 }
 
 func setupSCMock() serviceCentralClient {
@@ -56,32 +56,40 @@ func setupSCMock() serviceCentralClient {
 		Return(nil, nil)
 	scStore.
 		On("ListServices", mock.Anything, auth.NoUser(), makeSearchString(dougComputeService)).
-		Return(servicecentral.ServiceData{
-			ServiceName: dougComputeService,
+		Return(servicecentral.ServiceDataRead{
+			ServiceDataWrite: servicecentral.ServiceDataWrite{
+				ServiceName: dougComputeService,
+			},
 			ServiceOwner: servicecentral.ServiceOwner{
 				Username: "doug",
 			},
 		}, nil)
 	scStore.
 		On("ListServices", mock.Anything, auth.NoUser(), makeSearchString(dougMicros2Service)).
-		Return(servicecentral.ServiceData{
-			ServiceName: dougMicros2Service,
+		Return(servicecentral.ServiceDataRead{
+			ServiceDataWrite: servicecentral.ServiceDataWrite{
+				ServiceName: dougMicros2Service,
+			},
 			ServiceOwner: servicecentral.ServiceOwner{
 				Username: "doug",
 			},
 		}, nil)
 	scStore.
 		On("ListServices", mock.Anything, auth.NoUser(), makeSearchString(elsieComputeService)).
-		Return(servicecentral.ServiceData{
-			ServiceName: elsieComputeService,
+		Return(servicecentral.ServiceDataRead{
+			ServiceDataWrite: servicecentral.ServiceDataWrite{
+				ServiceName: elsieComputeService,
+			},
 			ServiceOwner: servicecentral.ServiceOwner{
 				Username: "elsie",
 			},
 		}, nil)
 	scStore.
 		On("ListServices", mock.Anything, auth.NoUser(), makeSearchString(elsieMicros2Service)).
-		Return(servicecentral.ServiceData{
-			ServiceName: elsieMicros2Service,
+		Return(servicecentral.ServiceDataRead{
+			ServiceDataWrite: servicecentral.ServiceDataWrite{
+				ServiceName: elsieMicros2Service,
+			},
 			ServiceOwner: servicecentral.ServiceOwner{
 				Username: "elsie",
 			},

--- a/pkg/servicecentral/client.go
+++ b/pkg/servicecentral/client.go
@@ -54,7 +54,7 @@ func NewServiceCentralClient(logger *zap.Logger, httpClient *http.Client, asap p
 // - 400: Bad request
 // - 409: The service UUID or service name already exists
 // - 500: Internal server error
-func (c *Client) CreateService(ctx context.Context, user auth.User, data *ServiceData) (*ServiceData, error) {
+func (c *Client) CreateService(ctx context.Context, user auth.User, data *ServiceDataWrite) (*ServiceDataRead, error) {
 	req, err := c.rm.NewRequest(
 		pkiutil.AuthenticateWithASAP(c.asap, asapAudience, user.Name()),
 		restclient.Method(http.MethodPost),
@@ -98,7 +98,7 @@ func (c *Client) CreateService(ctx context.Context, user auth.User, data *Servic
 // Patch an existing service with the attached specification
 // return codes:
 // - 200: The service was successfully updated
-func (c *Client) PatchService(ctx context.Context, user auth.User, data *ServiceData) error {
+func (c *Client) PatchService(ctx context.Context, user auth.User, data *ServiceDataWrite) error {
 	updateData := *data
 	updateData.ServiceUUID = nil
 	updateData.ServiceName = ""
@@ -141,8 +141,8 @@ func (c *Client) PatchService(ctx context.Context, user auth.User, data *Service
 // return codes:
 // - 200: OK
 // - 400: Bad request
-func (c *Client) ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]ServiceData, error) {
-	var results []ServiceData
+func (c *Client) ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]ServiceDataRead, error) {
+	var results []ServiceDataRead
 
 	offset := "0"
 	for {
@@ -169,7 +169,7 @@ func (c *Client) ListServices(ctx context.Context, user auth.OptionalUser, searc
 }
 
 // List recently modified services
-func (c *Client) ListModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceData, error) {
+func (c *Client) ListModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceDataRead, error) {
 	// The wrapper function is useless at the moment, but hopefully the endpoint will support paging functionality in the future...
 	return c.listModifiedServices(ctx, user, modifiedSince)
 }
@@ -220,7 +220,7 @@ func (c *Client) listServices(ctx context.Context, user auth.OptionalUser, searc
 	return parsedBody, nil
 }
 
-func (c *Client) listModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceData, error) {
+func (c *Client) listModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceDataRead, error) {
 	modifiedOnStr := modifiedSince.UTC().Format(time.RFC3339)
 	req, err := c.rm.NewRequest(
 		pkiutil.AuthenticateWithASAP(c.asap, asapAudience, user.NameOrElse(noUser)),
@@ -258,7 +258,7 @@ func (c *Client) listModifiedServices(ctx context.Context, user auth.OptionalUse
 	return convertV2ServicesToV1(parsedBody), nil
 }
 
-func (c *Client) GetService(ctx context.Context, user auth.OptionalUser, serviceUUID string) (*ServiceData, error) {
+func (c *Client) GetService(ctx context.Context, user auth.OptionalUser, serviceUUID string) (*ServiceDataRead, error) {
 	req, err := c.rm.NewRequest(
 		pkiutil.AuthenticateWithASAP(c.asap, asapAudience, user.NameOrElse(noUser)),
 		restclient.Method(http.MethodGet),
@@ -341,17 +341,19 @@ func clientError(statusCode int, message string) error {
 	}
 }
 
-func convertV2ServicesToV1(v2Services []V2Service) []ServiceData {
-	services := make([]ServiceData, 0, len(v2Services))
+func convertV2ServicesToV1(v2Services []V2Service) []ServiceDataRead {
+	services := make([]ServiceDataRead, 0, len(v2Services))
 	for _, v2Service := range v2Services {
 		services = append(services, convertV2ServiceToV1(v2Service))
 	}
 	return services
 }
 
-func convertV2ServiceToV1(v2Service V2Service) ServiceData {
-	service := ServiceData{
-		ServiceName: ServiceName(v2Service.Name),
+func convertV2ServiceToV1(v2Service V2Service) ServiceDataRead {
+	service := ServiceDataRead{
+		ServiceDataWrite: ServiceDataWrite{
+			ServiceName: ServiceName(v2Service.Name),
+		},
 		ServiceOwner: ServiceOwner{
 			Username: v2Service.Owner,
 		},

--- a/pkg/servicecentral/client_test.go
+++ b/pkg/servicecentral/client_test.go
@@ -281,6 +281,10 @@ func newReadData(setID bool) *ServiceDataRead {
 		ServiceDataWrite: *newWriteData(setID),
 		ServiceOwner:     ServiceOwner{Username: testUser.Name()},
 	}
+	if setID {
+		creationTimestamp := testCreationTimestamp
+		s.CreationTimestamp = &creationTimestamp
+	}
 	return &s
 }
 
@@ -303,8 +307,6 @@ func newWriteData(setID bool) *ServiceDataWrite {
 	if setID {
 		serviceUUID := testServiceUUID
 		s.ServiceUUID = &serviceUUID
-		creationTimestamp := testCreationTimestamp
-		s.CreationTimestamp = &creationTimestamp
 	}
 	return &s
 }

--- a/pkg/servicecentral/metadata.go
+++ b/pkg/servicecentral/metadata.go
@@ -15,7 +15,7 @@ const (
 )
 
 // GetPagerDutyMetadata reads the pagerduty metadata out of a service
-func GetPagerDutyMetadata(serviceCentralData *ServiceData) (*creator_v1.PagerDutyMetadata, error) {
+func GetPagerDutyMetadata(serviceCentralData *ServiceDataWrite) (*creator_v1.PagerDutyMetadata, error) {
 	var m creator_v1.PagerDutyMetadata
 	found, err := unmarshalFromMiscData(serviceCentralData, PagerDutyMetadataKey, &m)
 	if err != nil || !found {
@@ -25,12 +25,12 @@ func GetPagerDutyMetadata(serviceCentralData *ServiceData) (*creator_v1.PagerDut
 }
 
 // SetPagerDutyMetadata stores the metadata for pagerduty into a Service's metadata
-func SetPagerDutyMetadata(serviceCentralData *ServiceData, m *creator_v1.PagerDutyMetadata) error {
+func SetPagerDutyMetadata(serviceCentralData *ServiceDataWrite, m *creator_v1.PagerDutyMetadata) error {
 	return setMetadata(serviceCentralData, PagerDutyMetadataKey, m)
 }
 
 // GetBambooMetadata reads the allowed builds metadata out of a service
-func GetBambooMetadata(serviceCentralData *ServiceData) (*creator_v1.BambooMetadata, error) {
+func GetBambooMetadata(serviceCentralData *ServiceDataWrite) (*creator_v1.BambooMetadata, error) {
 	var m creator_v1.BambooMetadata
 	found, err := unmarshalFromMiscData(serviceCentralData, BambooMetadataKey, &m)
 	if err != nil || !found {
@@ -40,11 +40,11 @@ func GetBambooMetadata(serviceCentralData *ServiceData) (*creator_v1.BambooMetad
 }
 
 // SetBambooMetadata stores the metadata for allowed builds into a Service's metadata
-func SetBambooMetadata(serviceCentralData *ServiceData, m *creator_v1.BambooMetadata) error {
+func SetBambooMetadata(serviceCentralData *ServiceDataWrite, m *creator_v1.BambooMetadata) error {
 	return setMetadata(serviceCentralData, BambooMetadataKey, m)
 }
 
-func unmarshalFromMiscData(serviceCentralData *ServiceData, key string, res interface{}) (bool, error) {
+func unmarshalFromMiscData(serviceCentralData *ServiceDataWrite, key string, res interface{}) (bool, error) {
 	raw, err := GetMiscData(serviceCentralData, key)
 	if err != nil {
 		return false, err
@@ -59,7 +59,7 @@ func unmarshalFromMiscData(serviceCentralData *ServiceData, key string, res inte
 	return true, nil
 }
 
-func setMetadata(serviceCentralData *ServiceData, key string, m interface{}) error {
+func setMetadata(serviceCentralData *ServiceDataWrite, key string, m interface{}) error {
 	if m == nil {
 		return nil
 	}

--- a/pkg/servicecentral/metadata_test.go
+++ b/pkg/servicecentral/metadata_test.go
@@ -11,7 +11,7 @@ import (
 func TestSetsAndGetsMetadataCorrectly(t *testing.T) {
 	t.Parallel()
 
-	serviceData := &ServiceData{}
+	serviceData := &ServiceDataWrite{}
 
 	pdMetadata := creator_v1.PagerDutyMetadata{
 		Staging: creator_v1.PagerDutyEnvMetadata{
@@ -41,16 +41,18 @@ func TestGetMetadataReturnsErrorWhenMiscHasInvalidJSON(t *testing.T) {
 	t.Parallel()
 
 	// we have to know how it's stored in the misc field unfortunately...
-	serviceData := &ServiceData{
-		Misc: []miscData{
-			{
-				Key:   PagerDutyMetadataKey,
-				Value: "{ \"foo\": notvalid }", // not valid json
+	serviceData := &ServiceDataRead{
+		ServiceDataWrite: ServiceDataWrite{
+			Misc: []miscData{
+				{
+					Key:   PagerDutyMetadataKey,
+					Value: "{ \"foo\": notvalid }", // not valid json
+				},
 			},
 		},
 	}
 
-	_, err := GetPagerDutyMetadata(serviceData)
+	_, err := GetPagerDutyMetadata(&serviceData.ServiceDataWrite)
 
 	require.Error(t, err)
 }
@@ -58,7 +60,7 @@ func TestGetMetadataReturnsErrorWhenMiscHasInvalidJSON(t *testing.T) {
 func TestGetMetadataReturnsNilWhenNoPreviousData(t *testing.T) {
 	t.Parallel()
 
-	actual, err := GetPagerDutyMetadata(&ServiceData{})
+	actual, err := GetPagerDutyMetadata(&ServiceDataWrite{})
 
 	require.NoError(t, err)
 	assert.Nil(t, actual)
@@ -67,7 +69,7 @@ func TestGetMetadataReturnsNilWhenNoPreviousData(t *testing.T) {
 func TestSetsAndGetsBuildsCorrectly(t *testing.T) {
 	t.Parallel()
 
-	serviceData := &ServiceData{}
+	serviceData := &ServiceDataRead{}
 
 	buildMetadata := creator_v1.BambooMetadata{
 		Builds: []creator_v1.BambooPlanRef{
@@ -84,10 +86,10 @@ func TestSetsAndGetsBuildsCorrectly(t *testing.T) {
 		},
 	}
 
-	err := SetBambooMetadata(serviceData, &buildMetadata)
+	err := SetBambooMetadata(&serviceData.ServiceDataWrite, &buildMetadata)
 	require.NoError(t, err)
 
-	actual, err := GetBambooMetadata(serviceData)
+	actual, err := GetBambooMetadata(&serviceData.ServiceDataWrite)
 
 	require.NoError(t, err)
 	assert.Equal(t, &buildMetadata, actual)
@@ -97,16 +99,18 @@ func TestGetBuildsReturnsErrorWhenMiscHasInvalidJSON(t *testing.T) {
 	t.Parallel()
 
 	// we have to know how it's stored in the misc field unfortunately...
-	serviceData := &ServiceData{
-		Misc: []miscData{
-			{
-				Key:   BambooMetadataKey,
-				Value: "{ \"foo\": notvalid }", // not valid json
+	serviceData := &ServiceDataRead{
+		ServiceDataWrite: ServiceDataWrite{
+			Misc: []miscData{
+				{
+					Key:   BambooMetadataKey,
+					Value: "{ \"foo\": notvalid }", // not valid json
+				},
 			},
 		},
 	}
 
-	_, err := GetBambooMetadata(serviceData)
+	_, err := GetBambooMetadata(&serviceData.ServiceDataWrite)
 
 	require.Error(t, err)
 }
@@ -114,7 +118,7 @@ func TestGetBuildsReturnsErrorWhenMiscHasInvalidJSON(t *testing.T) {
 func TestGetBuildsReturnsNilWhenNoPreviousData(t *testing.T) {
 	t.Parallel()
 
-	actual, err := GetBambooMetadata(&ServiceData{})
+	actual, err := GetBambooMetadata(&ServiceDataWrite{})
 
 	require.NoError(t, err)
 	assert.Nil(t, actual)

--- a/pkg/servicecentral/store.go
+++ b/pkg/servicecentral/store.go
@@ -20,11 +20,11 @@ const (
 )
 
 type serviceCentralClient interface {
-	CreateService(ctx context.Context, user auth.User, data *ServiceData) (*ServiceData, error)
-	ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]ServiceData, error)
-	ListModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceData, error)
-	GetService(ctx context.Context, user auth.OptionalUser, serviceUUID string) (*ServiceData, error)
-	PatchService(ctx context.Context, user auth.User, data *ServiceData) error
+	CreateService(ctx context.Context, user auth.User, data *ServiceDataWrite) (*ServiceDataRead, error)
+	ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]ServiceDataRead, error)
+	ListModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceDataRead, error)
+	GetService(ctx context.Context, user auth.OptionalUser, serviceUUID string) (*ServiceDataRead, error)
+	PatchService(ctx context.Context, user auth.User, data *ServiceDataWrite) error
 	DeleteService(ctx context.Context, user auth.User, serviceUUID string) error
 }
 
@@ -42,7 +42,7 @@ func NewStore(logger *zap.Logger, client serviceCentralClient) *Store {
 }
 
 func (c *Store) FindOrCreateService(ctx context.Context, user auth.User, service *creator_v1.Service) (*creator_v1.Service, error) {
-	data, err := serviceToServiceData(ServiceData{}, service)
+	data, err := prepareServiceToWrite(ServiceDataRead{}, service)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (c *Store) FindOrCreateService(ctx context.Context, user auth.User, service
 	}
 
 	if httputil.IsConflict(err) {
-		actual, err = c.validateExistingService(ctx, auth.ToOptionalUser(user), data)
+		actual, err = c.validateExistingService(ctx, auth.ToOptionalUser(user), service.Spec.ResourceOwner, data)
 		if err != nil {
 			return nil, errors.Wrapf(err, "conflicting service %q already exists", data.ServiceName)
 		}
@@ -112,7 +112,7 @@ func (c *Store) PatchService(ctx context.Context, user auth.User, service *creat
 	if err != nil {
 		return err
 	}
-	updatedData, err := serviceToServiceData(*existingData, service)
+	updatedData, err := prepareServiceToWrite(*existingData, service)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (c *Store) DeleteService(ctx context.Context, user auth.User, name ServiceN
 	return nil
 }
 
-func (c *Store) getServiceDataByName(ctx context.Context, user auth.OptionalUser, name ServiceName) (*ServiceData, error) {
+func (c *Store) getServiceDataByName(ctx context.Context, user auth.OptionalUser, name ServiceName) (*ServiceDataRead, error) {
 	search := fmt.Sprintf("service_name='%s' AND platform='%s'", name, voyagerPlatform)
 	listData, err := c.client.ListServices(ctx, user, search)
 
@@ -169,7 +169,7 @@ func (c *Store) getServiceDataByName(ctx context.Context, user auth.OptionalUser
 	return nil, NewNotFound("service %q was not found", name)
 }
 
-func (c *Store) getServiceDataByUUID(ctx context.Context, user auth.OptionalUser, uuid string) (*ServiceData, error) {
+func (c *Store) getServiceDataByUUID(ctx context.Context, user auth.OptionalUser, uuid string) (*ServiceDataRead, error) {
 	data, err := c.client.GetService(ctx, user, uuid)
 
 	if err != nil {
@@ -182,7 +182,7 @@ func (c *Store) getServiceDataByUUID(ctx context.Context, user auth.OptionalUser
 	return data, nil
 }
 
-func (c *Store) validateExistingService(ctx context.Context, user auth.OptionalUser, data *ServiceData) (*ServiceData, error) {
+func (c *Store) validateExistingService(ctx context.Context, user auth.OptionalUser, originalOwner string, data *ServiceDataWrite) (*ServiceDataRead, error) {
 	search := fmt.Sprintf("service_name='%s'", data.ServiceName)
 	result, err := c.client.ListServices(ctx, user, search)
 	if err != nil {
@@ -197,8 +197,8 @@ func (c *Store) validateExistingService(ctx context.Context, user auth.OptionalU
 	if existingService.ServiceName != data.ServiceName {
 		return nil, errors.Errorf("searching for %q returned %q", data.ServiceName, existingService.ServiceName)
 	}
-	if existingService.ServiceOwner.Username != data.ServiceOwner.Username {
-		return nil, errors.Errorf("%q not allowed to use service owned by %q", data.ServiceOwner.Username, existingService.ServiceOwner.Username)
+	if existingService.ServiceOwner.Username != originalOwner {
+		return nil, errors.Errorf("%q not allowed to use service owned by %q", originalOwner, existingService.ServiceOwner.Username)
 	}
 	if existingService.Platform != voyagerPlatform {
 		return nil, errors.Errorf("invalid service platform: expected=%q, actual=%q", voyagerPlatform, existingService.Platform)
@@ -207,7 +207,7 @@ func (c *Store) validateExistingService(ctx context.Context, user auth.OptionalU
 	return c.getServiceDataByUUID(ctx, user, *existingService.ServiceUUID)
 }
 
-func fillServiceDataDefaults(data *ServiceData) {
+func fillServiceDataDefaults(data *ServiceDataWrite) {
 	if data.ServiceTier == 0 {
 		data.ServiceTier = defaultServiceTier
 	}
@@ -216,17 +216,18 @@ func fillServiceDataDefaults(data *ServiceData) {
 	data.Platform = voyagerPlatform
 }
 
-func serviceToServiceData(existingData ServiceData, service *creator_v1.Service) (*ServiceData, error) {
+// prepareServiceToWrite creates a valid service data for writing to Service Central
+// Note: It cannot set Service Owner see: VYGR-425
+func prepareServiceToWrite(existingData ServiceDataRead, service *creator_v1.Service) (*ServiceDataWrite, error) {
 	serviceUID := string(service.GetUID())
 	var serviceUUID *string
 	if len(serviceUID) != 0 {
 		serviceUUID = &serviceUID
 	}
 
-	sd := ServiceData{
+	sd := ServiceDataWrite{
 		ServiceUUID:        serviceUUID,
 		ServiceName:        ServiceName(service.Name),
-		ServiceOwner:       ServiceOwner{Username: service.Spec.ResourceOwner},
 		BusinessUnit:       service.Spec.BusinessUnit,
 		SSAMContainerName:  service.Spec.SSAMContainerName,
 		LoggingID:          service.Spec.LoggingID,
@@ -260,7 +261,7 @@ func serviceToServiceData(existingData ServiceData, service *creator_v1.Service)
 	return &sd, nil
 }
 
-func serviceDataToService(data *ServiceData) (*creator_v1.Service, error) {
+func serviceDataToService(data *ServiceDataRead) (*creator_v1.Service, error) {
 	var serviceUID string
 	if data.ServiceUUID != nil {
 		serviceUID = *data.ServiceUUID
@@ -292,7 +293,7 @@ func serviceDataToService(data *ServiceData) (*creator_v1.Service, error) {
 		}
 	}
 
-	pagerDutyMetadata, err := GetPagerDutyMetadata(data)
+	pagerDutyMetadata, err := GetPagerDutyMetadata(&data.ServiceDataWrite)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func serviceDataToService(data *ServiceData) (*creator_v1.Service, error) {
 		service.Spec.Metadata.PagerDuty = pagerDutyMetadata
 	}
 
-	bambooMetadata, err := GetBambooMetadata(data)
+	bambooMetadata, err := GetBambooMetadata(&data.ServiceDataWrite)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +319,7 @@ func serviceDataToService(data *ServiceData) (*creator_v1.Service, error) {
 	return service, nil
 }
 
-func GetMiscData(data *ServiceData, key string) (string, error) {
+func GetMiscData(data *ServiceDataWrite, key string) (string, error) {
 	for _, miscData := range data.Misc {
 		if miscData.Key == key {
 			return miscData.Value, nil
@@ -327,7 +328,7 @@ func GetMiscData(data *ServiceData, key string) (string, error) {
 	return "", nil
 }
 
-func SetMiscData(data *ServiceData, key string, value string) error {
+func SetMiscData(data *ServiceDataWrite, key string, value string) error {
 	result := make([]miscData, 0, len(data.Misc))
 	for _, miscData := range data.Misc {
 		if miscData.Key == key {

--- a/pkg/servicecentral/store_test.go
+++ b/pkg/servicecentral/store_test.go
@@ -540,6 +540,10 @@ func newServiceServiceCentralDataRead(setID bool) *ServiceDataRead {
 		ServiceDataWrite: *newServiceServiceCentralDataWrite(setID),
 		ServiceOwner:     ServiceOwner{Username: testUser.Name()},
 	}
+	if setID {
+		creationTimestamp := testCreationTimestamp
+		sd.CreationTimestamp = &creationTimestamp
+	}
 	return &sd
 }
 
@@ -555,8 +559,6 @@ func newServiceServiceCentralDataWrite(setID bool) *ServiceDataWrite {
 	if setID {
 		serviceUUID := testServiceUUID
 		sd.ServiceUUID = &serviceUUID
-		creationTimestamp := testCreationTimestamp
-		sd.CreationTimestamp = &creationTimestamp
 	}
 	return &sd
 }
@@ -573,8 +575,6 @@ func newServiceWriteData(setID bool) *ServiceDataWrite {
 	if setID {
 		serviceUUID := testServiceUUID
 		sd.ServiceUUID = &serviceUUID
-		creationTimestamp := testCreationTimestamp
-		sd.CreationTimestamp = &creationTimestamp
 	}
 	return &sd
 }

--- a/pkg/servicecentral/store_test.go
+++ b/pkg/servicecentral/store_test.go
@@ -31,32 +31,32 @@ type serviceCentralClientMock struct {
 // Making sure that mock implements the interface
 var _ serviceCentralClient = &serviceCentralClientMock{}
 
-func (m *serviceCentralClientMock) CreateService(ctx context.Context, user auth.User, data *ServiceData) (*ServiceData, error) {
+func (m *serviceCentralClientMock) CreateService(ctx context.Context, user auth.User, data *ServiceDataWrite) (*ServiceDataRead, error) {
 	args := m.Called(ctx, user, data)
 	result := args.Get(0)
 	if result == nil {
 		return nil, args.Error(1)
 	}
-	return result.(*ServiceData), args.Error(1)
+	return result.(*ServiceDataRead), args.Error(1)
 }
 
-func (m *serviceCentralClientMock) ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]ServiceData, error) {
+func (m *serviceCentralClientMock) ListServices(ctx context.Context, user auth.OptionalUser, search string) ([]ServiceDataRead, error) {
 	args := m.Called(ctx, user, search)
-	return args.Get(0).([]ServiceData), args.Error(1)
+	return args.Get(0).([]ServiceDataRead), args.Error(1)
 }
 
-func (m *serviceCentralClientMock) ListModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceData, error) {
+func (m *serviceCentralClientMock) ListModifiedServices(ctx context.Context, user auth.OptionalUser, modifiedSince time.Time) ([]ServiceDataRead, error) {
 	args := m.Called(ctx, user, modifiedSince)
-	return args.Get(0).([]ServiceData), args.Error(1)
+	return args.Get(0).([]ServiceDataRead), args.Error(1)
 }
 
-func (m *serviceCentralClientMock) GetService(ctx context.Context, user auth.OptionalUser, serviceUUID string) (*ServiceData, error) {
+func (m *serviceCentralClientMock) GetService(ctx context.Context, user auth.OptionalUser, serviceUUID string) (*ServiceDataRead, error) {
 	args := m.Called(ctx, user, serviceUUID)
-	ret1, _ := args.Get(0).(*ServiceData)
+	ret1, _ := args.Get(0).(*ServiceDataRead)
 	return ret1, args.Error(1)
 }
 
-func (m *serviceCentralClientMock) PatchService(ctx context.Context, user auth.User, data *ServiceData) error {
+func (m *serviceCentralClientMock) PatchService(ctx context.Context, user auth.User, data *ServiceDataWrite) error {
 	args := m.Called(ctx, user, data)
 	return args.Error(0)
 }
@@ -70,7 +70,7 @@ func TestCreateService(t *testing.T) {
 	t.Parallel()
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	serviceCentralClient.On("CreateService", mock.Anything, testUser, newServiceServiceCentralData(false)).Return(newServiceServiceCentralData(true), nil)
+	serviceCentralClient.On("CreateService", mock.Anything, testUser, newServiceWriteData(false)).Return(newServiceServiceCentralDataRead(true), nil)
 	store := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 	// when
 	result, err := store.FindOrCreateService(context.Background(), testUser, newService(false))
@@ -82,10 +82,10 @@ func TestCreateService(t *testing.T) {
 func TestCreateServiceSucceedsIfServiceWithTheSameDataExistsStore(t *testing.T) {
 	t.Parallel()
 	// given
-	existingServiceData := newServiceServiceCentralData(true)
+	existingServiceData := newServiceServiceCentralDataRead(true)
 	serviceCentralClient := new(serviceCentralClientMock)
-	serviceCentralClient.On("CreateService", mock.Anything, mock.Anything, mock.Anything).Return((*ServiceData)(nil), httputil.NewConflict("already exists"))
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, "service_name='test-service'").Return([]ServiceData{*existingServiceData}, nil)
+	serviceCentralClient.On("CreateService", mock.Anything, mock.Anything, mock.Anything).Return((*ServiceDataRead)(nil), httputil.NewConflict("already exists"))
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, "service_name='test-service'").Return([]ServiceDataRead{*existingServiceData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, *existingServiceData.ServiceUUID).Return(existingServiceData, nil)
 	store := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 	// when
@@ -98,11 +98,11 @@ func TestCreateServiceSucceedsIfServiceWithTheSameDataExistsStore(t *testing.T) 
 func TestCreateServiceFailsIfServiceWithTheSameNameButDifferentOwnerExistsStore(t *testing.T) {
 	t.Parallel()
 	// given
-	existingServiceData := newServiceServiceCentralData(true)
+	existingServiceData := newServiceServiceCentralDataRead(true)
 	existingServiceData.ServiceOwner.Username = "somebody-else"
 	serviceCentralClient := new(serviceCentralClientMock)
-	serviceCentralClient.On("CreateService", mock.Anything, mock.Anything, mock.Anything).Return((*ServiceData)(nil), httputil.NewConflict("already exists"))
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, "service_name='test-service'").Return([]ServiceData{*existingServiceData}, nil)
+	serviceCentralClient.On("CreateService", mock.Anything, mock.Anything, mock.Anything).Return((*ServiceDataRead)(nil), httputil.NewConflict("already exists"))
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, "service_name='test-service'").Return([]ServiceDataRead{*existingServiceData}, nil)
 	store := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 	// when
 	_, err := store.FindOrCreateService(context.Background(), testUser, newService(false))
@@ -115,8 +115,8 @@ func TestCreateServiceFailsIfServiceExistsButCouldNotBeFound(t *testing.T) {
 	t.Parallel()
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	serviceCentralClient.On("CreateService", mock.Anything, mock.Anything, mock.Anything).Return((*ServiceData)(nil), httputil.NewConflict("already exists"))
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, "service_name='test-service'").Return([]ServiceData{}, nil)
+	serviceCentralClient.On("CreateService", mock.Anything, mock.Anything, mock.Anything).Return((*ServiceDataRead)(nil), httputil.NewConflict("already exists"))
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, "service_name='test-service'").Return([]ServiceDataRead{}, nil)
 	store := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 	// when
 	_, err := store.FindOrCreateService(context.Background(), testUser, newService(false))
@@ -129,8 +129,8 @@ func TestGetServiceSearchesByNameAndPlatform(t *testing.T) {
 
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	expectedData := newTestServiceData(true)
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{*expectedData}, nil)
+	expectedData := newReadData(true)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{*expectedData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, mock.Anything).Return(expectedData, nil)
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
@@ -149,8 +149,8 @@ func TestGetServiceReturnsResult(t *testing.T) {
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
 	expectedService := newService(true)
-	expectedData := newTestServiceData(true)
-	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceData{*expectedData}, nil)
+	expectedData := newReadData(true)
+	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceDataRead{*expectedData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, optionalUser, mock.Anything).Return(expectedData, nil)
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
@@ -177,12 +177,12 @@ func TestGetServiceWithComplianceReturnsResult(t *testing.T) {
 		t.Run(fmt.Sprintf("PRGB=%v", tc.expectedVal), func(t *testing.T) {
 			serviceCentralClient := new(serviceCentralClientMock)
 			expectedService := newServiceWithCompliance(true, tc.expectedVal)
-			expectedData := newTestServiceData(true)
+			expectedData := newReadData(true)
 			expectedData.Compliance = &ServiceComplianceConf{
 				PRGBControl: &tc.expectedVal,
 			}
 
-			serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceData{*expectedData}, nil)
+			serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceDataRead{*expectedData}, nil)
 			serviceCentralClient.On("GetService", mock.Anything, optionalUser, mock.Anything).Return(expectedData, nil)
 			lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
@@ -202,12 +202,12 @@ func TestGetServiceReturnsSingleServiceIfMultiple(t *testing.T) {
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
 	expectedService := newService(true)
-	expectedData := newTestServiceData(true)
-	expectedData2 := newTestServiceData(true)
+	expectedData := newReadData(true)
+	expectedData2 := newReadData(true)
 	otherUuid := "some-uuid"
 	expectedData2.ServiceUUID = &otherUuid
 	expectedData2.ServiceName = "other-name"
-	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceData{*expectedData2, *expectedData}, nil)
+	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceDataRead{*expectedData2, *expectedData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, optionalUser, testServiceUUID).Return(expectedData, nil)
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
@@ -226,13 +226,13 @@ func TestGetServiceIncludesTags(t *testing.T) {
 	const serviceName = "some-service"
 	serviceCentralClient := new(serviceCentralClientMock)
 
-	sd := newTestServiceData(true)
+	sd := newReadData(true)
 	sd.Tags = []string{"will be discarded", "micros2:first=some=value", "micros2:second=space in value"}
 	sd.ServiceName = serviceName
 
 	expectedService := newService(true)
 	expectedService.Spec.ResourceTags = parsePlatformTags(sd.Tags)
-	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceData{*sd}, nil)
+	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceDataRead{*sd}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, optionalUser, *sd.ServiceUUID).Return(sd, nil)
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
@@ -249,7 +249,7 @@ func TestGetServiceReturnsErrorWhenServiceNotFound(t *testing.T) {
 
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceData{}, nil)
+	serviceCentralClient.On("ListServices", mock.Anything, optionalUser, mock.Anything).Return([]ServiceDataRead{}, nil)
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
 	// when
@@ -281,14 +281,16 @@ func TestPatchServiceUpdatesTagsRetainsPreviousValues(t *testing.T) {
 	}
 
 	serviceUUID := "some-uuid"
-	oldService := ServiceData{
-		ServiceUUID: &serviceUUID,
-		ServiceName: serviceName,
-		Tags:        []string{"random tag"},
+	oldService := ServiceDataRead{
+		ServiceDataWrite: ServiceDataWrite{
+			ServiceUUID: &serviceUUID,
+			ServiceName: serviceName,
+			Tags:        []string{"random tag"},
+		},
 	}
 	expectedTags := append(oldService.Tags, convertPlatformTags(updatedService.Spec.ResourceTags)...)
 
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{oldService}, nil)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{oldService}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, serviceUUID).Return(&oldService, nil)
 	serviceCentralClient.On("PatchService", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	store := NewStore(zaptest.NewLogger(t), serviceCentralClient)
@@ -305,7 +307,7 @@ func TestPatchServiceUpdatesTagsRetainsPreviousValues(t *testing.T) {
 			continue
 		}
 
-		data, ok := call.Arguments[2].(*ServiceData)
+		data, ok := call.Arguments[2].(*ServiceDataWrite)
 		require.True(t, ok)
 
 		// we only care about the tags for this test, and order isn't guaranteed
@@ -349,13 +351,15 @@ func TestPatchServiceRetainsMiscValues(t *testing.T) {
 	require.NoError(t, err)
 
 	serviceUUID := "some-uuid"
-	oldService := ServiceData{
-		ServiceUUID: &serviceUUID,
-		ServiceName: serviceName,
-		Misc: []miscData{
-			{Key: "ExistingKey", Value: "ExistingValue"},
-			{Key: PagerDutyMetadataKey, Value: "ToBeReplaced"},
-			{Key: BambooMetadataKey, Value: "ToBeReplaced"},
+	oldService := ServiceDataRead{
+		ServiceDataWrite: ServiceDataWrite{
+			ServiceUUID: &serviceUUID,
+			ServiceName: serviceName,
+			Misc: []miscData{
+				{Key: "ExistingKey", Value: "ExistingValue"},
+				{Key: PagerDutyMetadataKey, Value: "ToBeReplaced"},
+				{Key: BambooMetadataKey, Value: "ToBeReplaced"},
+			},
 		},
 	}
 	expectedMisc := []miscData{
@@ -364,7 +368,7 @@ func TestPatchServiceRetainsMiscValues(t *testing.T) {
 		{Key: BambooMetadataKey, Value: string(bambooMeta)},
 	}
 
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{oldService}, nil)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{oldService}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, serviceUUID).Return(&oldService, nil)
 	serviceCentralClient.On("PatchService", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	store := NewStore(zaptest.NewLogger(t), serviceCentralClient)
@@ -381,7 +385,7 @@ func TestPatchServiceRetainsMiscValues(t *testing.T) {
 			continue
 		}
 
-		data, ok := call.Arguments[2].(*ServiceData)
+		data, ok := call.Arguments[2].(*ServiceDataWrite)
 		require.True(t, ok)
 
 		// we only check the misc fields to see if they match
@@ -395,8 +399,8 @@ func TestDeleteServiceDeletesCorrectUUID(t *testing.T) {
 
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	expectedData := newTestServiceData(true)
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{*expectedData}, nil)
+	expectedData := newReadData(true)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{*expectedData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, mock.Anything).Return(expectedData, nil)
 	serviceCentralClient.On("DeleteService", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
@@ -414,8 +418,8 @@ func TestDeleteServiceTwiceGives404(t *testing.T) {
 
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	expectedData := newTestServiceData(true)
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{*expectedData}, nil)
+	expectedData := newReadData(true)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{*expectedData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, mock.Anything).Return(expectedData, nil)
 	serviceCentralClient.On("DeleteService", mock.Anything, mock.Anything, mock.Anything).Return(httputil.NewNotFound("oh no"))
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
@@ -434,7 +438,7 @@ func TestDeleteServiceMissingList(t *testing.T) {
 
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{}, nil)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{}, nil)
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
 	// when
@@ -451,8 +455,8 @@ func TestDeleteServiceMissingService(t *testing.T) {
 
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	expectedData := newTestServiceData(true)
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{*expectedData}, nil)
+	expectedData := newReadData(true)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{*expectedData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, mock.Anything).Return(nil, httputil.NewNotFound("oh no"))
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
 
@@ -470,8 +474,8 @@ func TestDeleteServiceWeirdResponse(t *testing.T) {
 
 	// given
 	serviceCentralClient := new(serviceCentralClientMock)
-	expectedData := newTestServiceData(true)
-	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceData{*expectedData}, nil)
+	expectedData := newReadData(true)
+	serviceCentralClient.On("ListServices", mock.Anything, mock.Anything, mock.Anything).Return([]ServiceDataRead{*expectedData}, nil)
 	serviceCentralClient.On("GetService", mock.Anything, mock.Anything, mock.Anything).Return(expectedData, nil)
 	serviceCentralClient.On("DeleteService", mock.Anything, mock.Anything, mock.Anything).Return(httputil.NewUnknown("oh no"))
 	lister := NewStore(zaptest.NewLogger(t), serviceCentralClient)
@@ -531,10 +535,35 @@ func newServiceWithCompliance(wasCreated bool, PRGBEnabled bool) *creator_v1.Ser
 	return &service
 }
 
-func newServiceServiceCentralData(setID bool) *ServiceData {
-	sd := ServiceData{
+func newServiceServiceCentralDataRead(setID bool) *ServiceDataRead {
+	sd := ServiceDataRead{
+		ServiceDataWrite: *newServiceServiceCentralDataWrite(setID),
+		ServiceOwner:     ServiceOwner{Username: testUser.Name()},
+	}
+	return &sd
+}
+
+func newServiceServiceCentralDataWrite(setID bool) *ServiceDataWrite {
+	sd := ServiceDataWrite{
 		ServiceName:          testServiceName,
-		ServiceOwner:         ServiceOwner{Username: testUser.Name()},
+		ServiceTier:          defaultServiceTier,
+		Platform:             voyagerPlatform,
+		ZeroDowntimeUpgrades: true,
+		Stateless:            true,
+		BusinessUnit:         "some_unit",
+	}
+	if setID {
+		serviceUUID := testServiceUUID
+		sd.ServiceUUID = &serviceUUID
+		creationTimestamp := testCreationTimestamp
+		sd.CreationTimestamp = &creationTimestamp
+	}
+	return &sd
+}
+
+func newServiceWriteData(setID bool) *ServiceDataWrite {
+	sd := ServiceDataWrite{
+		ServiceName:          testServiceName,
 		ServiceTier:          defaultServiceTier,
 		Platform:             voyagerPlatform,
 		ZeroDowntimeUpgrades: true,

--- a/pkg/servicecentral/types.go
+++ b/pkg/servicecentral/types.go
@@ -15,7 +15,6 @@ type ServiceOwner struct {
 
 type ServiceDataWrite struct {
 	ServiceUUID        *string     `json:"service_uuid,omitempty"`
-	CreationTimestamp  *string     `json:"creation_timestamp,omitempty"`
 	ServiceName        ServiceName `json:"service_name,omitempty"`
 	ServiceTier        int         `json:"service_tier,omitempty"`
 	Tags               []string    `json:"tags,omitempty"`
@@ -28,17 +27,18 @@ type ServiceDataWrite struct {
 	ZeroDowntimeUpgrades bool   `json:"zero_downtime_upgrades,omitempty"`
 	Stateless            bool   `json:"stateless,omitempty"`
 	BusinessUnit         string `json:"business_unit,omitempty"`
-
-	// Compliance is a read-only field. It can be nil, in which case it means
-	// they have not completed their compliance questions yet
-	Compliance *ServiceComplianceConf `json:"compliance,omitempty"`
 }
 
 type ServiceDataRead struct {
 	ServiceDataWrite
+	CreationTimestamp *string `json:"creation_timestamp,omitempty"`
 	// ServiceOwner is a read only field
 	// see: VYGR-425
 	ServiceOwner ServiceOwner `json:"service_owner,omitempty"`
+
+	// Compliance is a read-only field. It can be nil, in which case it means
+	// they have not completed their compliance questions yet
+	Compliance *ServiceComplianceConf `json:"compliance,omitempty"`
 }
 
 // ServiceComplianceConf includes all service compliance related data

--- a/pkg/servicecentral/types.go
+++ b/pkg/servicecentral/types.go
@@ -13,18 +13,17 @@ type ServiceOwner struct {
 	Username string `json:"username"`
 }
 
-type ServiceData struct {
-	ServiceUUID        *string      `json:"service_uuid,omitempty"`
-	CreationTimestamp  *string      `json:"creation_timestamp,omitempty"`
-	ServiceName        ServiceName  `json:"service_name,omitempty"`
-	ServiceOwner       ServiceOwner `json:"service_owner,omitempty"`
-	ServiceTier        int          `json:"service_tier,omitempty"`
-	Tags               []string     `json:"tags,omitempty"`
-	Platform           string       `json:"platform,omitempty"`
-	Misc               []miscData   `json:"misc,omitempty"`
-	PagerDutyServiceID string       `json:"pagerduty_service_id,omitempty"`
-	LoggingID          string       `json:"logging_id,omitempty"`
-	SSAMContainerName  string       `json:"ssam_container_name,omitempty"`
+type ServiceDataWrite struct {
+	ServiceUUID        *string     `json:"service_uuid,omitempty"`
+	CreationTimestamp  *string     `json:"creation_timestamp,omitempty"`
+	ServiceName        ServiceName `json:"service_name,omitempty"`
+	ServiceTier        int         `json:"service_tier,omitempty"`
+	Tags               []string    `json:"tags,omitempty"`
+	Platform           string      `json:"platform,omitempty"`
+	Misc               []miscData  `json:"misc,omitempty"`
+	PagerDutyServiceID string      `json:"pagerduty_service_id,omitempty"`
+	LoggingID          string      `json:"logging_id,omitempty"`
+	SSAMContainerName  string      `json:"ssam_container_name,omitempty"`
 
 	ZeroDowntimeUpgrades bool   `json:"zero_downtime_upgrades,omitempty"`
 	Stateless            bool   `json:"stateless,omitempty"`
@@ -33,6 +32,13 @@ type ServiceData struct {
 	// Compliance is a read-only field. It can be nil, in which case it means
 	// they have not completed their compliance questions yet
 	Compliance *ServiceComplianceConf `json:"compliance,omitempty"`
+}
+
+type ServiceDataRead struct {
+	ServiceDataWrite
+	// ServiceOwner is a read only field
+	// see: VYGR-425
+	ServiceOwner ServiceOwner `json:"service_owner,omitempty"`
 }
 
 // ServiceComplianceConf includes all service compliance related data
@@ -55,9 +61,9 @@ type metaResult struct {
 
 // Return value representing service and associated arbitrary metadata
 type serviceTypeResponse struct {
-	Data       []ServiceData `json:"data"`
-	Message    string        `json:"message"`
-	StatusCode int           `json:"status_code"`
+	Data       []ServiceDataRead `json:"data"`
+	Message    string            `json:"message"`
+	StatusCode int               `json:"status_code"`
 
 	// only useful for search list results
 	Meta metaResult `json:"meta"`
@@ -83,6 +89,7 @@ type V2Service struct {
 	Name string `json:"name" sql:"service_name,unique"`
 
 	// Owner of the service, must be an a valid staff ID of a person
+	// Owner is READ ONLY it cannot be set when talking to service central
 	Owner string `json:"owner" sql:"service_owner"`
 
 	// Name of the team who owns the service


### PR DESCRIPTION
ServiceOwner is only valid as when read. Updating the owner is no longer
supported, writing the owner during creation is deprecated.