### PR TITLE
MICROS-6921 Fix pod disruption budget for low minReplicas

### DIFF
--- a/pkg/orchestration/wiring/k8scompute/plugin.go
+++ b/pkg/orchestration/wiring/k8scompute/plugin.go
@@ -542,11 +542,11 @@ func buildPodDisruptionBudgetSpec(labelMap map[string]string, minReplicas int32)
 	var pdbPercentage string
 	switch minReplicas {
 	case 0, 1:
-		pdbPercentage = "100%"
+		pdbPercentage = "0%"
 	case 2:
 		pdbPercentage = "50%"
 	default:
-		pdbPercentage = "30%"
+		pdbPercentage = "66%"
 	}
 
 	return policy_v1.PodDisruptionBudgetSpec{

--- a/pkg/orchestration/wiring/k8scompute/plugin.go
+++ b/pkg/orchestration/wiring/k8scompute/plugin.go
@@ -539,20 +539,20 @@ func buildAntiAffinity(labelMap map[string]string) *core_v1.PodAntiAffinity {
 
 func buildPodDisruptionBudgetSpec(labelMap map[string]string, minReplicas int32) policy_v1.PodDisruptionBudgetSpec {
 	// Make sure we can drain nodes if the minReplicas is < 3
-	var pdbPercentage string
+	var minAvailable string
 	switch minReplicas {
 	case 0, 1:
-		pdbPercentage = "0%"
+		minAvailable = "0%"
 	case 2:
-		pdbPercentage = "50%"
+		minAvailable = "50%"
 	default:
-		pdbPercentage = "66%"
+		minAvailable = "66%"
 	}
 
 	return policy_v1.PodDisruptionBudgetSpec{
 		MinAvailable: &intstr.IntOrString{
 			Type:   intstr.String,
-			StrVal: pdbPercentage,
+			StrVal: minAvailable,
 		},
 		Selector: &meta_v1.LabelSelector{
 			MatchLabels: labelMap,

--- a/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
@@ -148,7 +148,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
@@ -148,7 +148,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
@@ -1350,7 +1350,7 @@ spec:
         metadata:
           name: kc--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kc

--- a/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
@@ -1350,7 +1350,7 @@ spec:
         metadata:
           name: kc--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kc

--- a/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.pdb.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.pdb.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: c1--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 30%
           selector:
             matchLabels:
               resourceName: c1
@@ -48,7 +48,7 @@ spec:
           name: c1
         spec:
           progressDeadlineSeconds: 600
-          replicas: 1
+          replicas: 5
           revisionHistoryLimit: 0
           selector:
             matchLabels:
@@ -115,15 +115,49 @@ spec:
                 - secretRef:
                     name: common-secrets
                     optional: true
-                image: docker.example.com/atlassian/micros-analytics:0.1.8
+                image: docker.example.com/atlassian/micros-analytics:0.1
+                imagePullPolicy: IfNotPresent
                 name: microservice
+                ports:
+                - containerPort: 8080
+                  protocol: TCP
                 resources:
                   limits:
-                    cpu: "0"
-                    memory: "0"
+                    cpu: 500m
+                    memory: 128Mi
                   requests:
-                    cpu: "0"
-                    memory: "0"
+                    cpu: 250m
+                    memory: 64Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              - env:
+                - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
+                  value: https://asap-distribution.us-west-1.staging.paas-inf.net/
+                - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
+                  value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                - name: MICROS_AWS_REGION
+                  value: testregion
+                - name: MICROS_ENVTYPE
+                  value: testenv
+                - name: MICROS_SERVICE
+                  value: test-servicename
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
+                image: docker.example.com/my_pgbouncer:abcxyz
+                imagePullPolicy: IfNotPresent
+                name: pgbouncer
+                ports:
+                - containerPort: 5432
+                  protocol: UDP
+                resources:
+                  limits:
+                    cpu: 250m
+                    memory: 150Mi
+                  requests:
+                    cpu: 50m
+                    memory: 50Mi
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
               dnsPolicy: ClusterFirst
@@ -132,6 +166,33 @@ spec:
               securityContext: {}
               serviceAccountName: '!{c1--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
+  - name: c1--hpa
+    references:
+    - name: c1-metadata-name
+      path: metadata.name
+      resource: c1
+    spec:
+      object:
+        apiVersion: autoscaling/v2beta1
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: c1--hpa
+        spec:
+          maxReplicas: 10
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 50
+            type: Resource
+          - resource:
+              name: memory
+              targetAverageValue: 50Mi
+            type: Resource
+          minReplicas: 5
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: '!{c1-metadata-name}'
   - name: c2--svcacc
     spec:
       object:
@@ -149,7 +210,7 @@ spec:
         metadata:
           name: c2--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 50%
           selector:
             matchLabels:
               resourceName: c2
@@ -167,7 +228,7 @@ spec:
           name: c2
         spec:
           progressDeadlineSeconds: 600
-          replicas: 1
+          replicas: 2
           revisionHistoryLimit: 0
           selector:
             matchLabels:
@@ -234,15 +295,49 @@ spec:
                 - secretRef:
                     name: common-secrets
                     optional: true
-                image: docker.example.com/atlassian/micros-analytics:0.1.8
+                image: docker.example.com/atlassian/micros-analytics:0.1
+                imagePullPolicy: IfNotPresent
                 name: microservice
+                ports:
+                - containerPort: 8080
+                  protocol: TCP
                 resources:
                   limits:
-                    cpu: "0"
-                    memory: "0"
+                    cpu: 500m
+                    memory: 128Mi
                   requests:
-                    cpu: "0"
-                    memory: "0"
+                    cpu: 250m
+                    memory: 64Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              - env:
+                - name: ASAP_PUBLIC_KEY_REPOSITORY_URL
+                  value: https://asap-distribution.us-west-1.staging.paas-inf.net/
+                - name: ASAP_PUBLIC_KEY_FALLBACK_REPOSITORY_URL
+                  value: https://asap-distribution.us-east-1.staging.paas-inf.net/
+                - name: MICROS_AWS_REGION
+                  value: testregion
+                - name: MICROS_ENVTYPE
+                  value: testenv
+                - name: MICROS_SERVICE
+                  value: test-servicename
+                envFrom:
+                - secretRef:
+                    name: common-secrets
+                    optional: true
+                image: docker.example.com/my_pgbouncer:abcxyz
+                imagePullPolicy: IfNotPresent
+                name: pgbouncer
+                ports:
+                - containerPort: 5432
+                  protocol: UDP
+                resources:
+                  limits:
+                    cpu: 250m
+                    memory: 150Mi
+                  requests:
+                    cpu: 50m
+                    memory: 50Mi
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
               dnsPolicy: ClusterFirst
@@ -251,202 +346,31 @@ spec:
               securityContext: {}
               serviceAccountName: '!{c2--svcacc-metadata-name}'
               terminationGracePeriodSeconds: 30
-  - name: ingress1--service
+  - name: c2--hpa
     references:
-    - resource: c1
+    - name: c2-metadata-name
+      path: metadata.name
+      resource: c2
     spec:
       object:
-        apiVersion: v1
-        kind: Service
+        apiVersion: autoscaling/v2beta1
+        kind: HorizontalPodAutoscaler
         metadata:
-          name: ingress1--service
+          name: c2--hpa
         spec:
-          ports:
-          - name: http
-            port: 8080
-            protocol: TCP
-            targetPort: 8080
-          selector:
-            resourceName: c1
-            stateName: state1
-          sessionAffinity: None
-          type: ClusterIP
-  - name: ingress1
-    references:
-    - resource: ingress1--service
-    spec:
-      object:
-        apiVersion: extensions/v1beta1
-        kind: Ingress
-        metadata:
-          annotations:
-            contour.heptio.com/request-timeout: 60s
-            voyager.atl-paas.net/ingressType: private
-          name: ingress1
-        spec:
-          rules:
-          - host: test-servicename--ingress1.testregion.testenv.k8s.atl-paas.net
-            http:
-              paths:
-              - backend:
-                  serviceName: ingress1--service
-                  servicePort: 8080
-                path: /
-          - host: foo11.staging.atl-paas.net
-            http:
-              paths:
-              - backend:
-                  serviceName: ingress1--service
-                  servicePort: 8080
-                path: /
-          - host: foo12.staging.atl-paas.net
-            http:
-              paths:
-              - backend:
-                  serviceName: ingress1--service
-                  servicePort: 8080
-                path: /
-  - name: ingress2--service
-    references:
-    - resource: c2
-    spec:
-      object:
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: ingress2--service
-        spec:
-          ports:
-          - name: http
-            port: 8080
-            protocol: TCP
-            targetPort: 8080
-          selector:
-            resourceName: c2
-            stateName: state1
-          sessionAffinity: None
-          type: ClusterIP
-  - name: ingress2
-    references:
-    - resource: ingress2--service
-    spec:
-      object:
-        apiVersion: extensions/v1beta1
-        kind: Ingress
-        metadata:
-          annotations:
-            contour.heptio.com/request-timeout: 60s
-            voyager.atl-paas.net/ingressType: private
-          name: ingress2
-        spec:
-          rules:
-          - host: test-servicename--ingress2.testregion.testenv.k8s.atl-paas.net
-            http:
-              paths:
-              - backend:
-                  serviceName: ingress2--service
-                  servicePort: 8080
-                path: /
-          - host: foo21.staging.atl-paas.net
-            http:
-              paths:
-              - backend:
-                  serviceName: ingress2--service
-                  servicePort: 8080
-                path: /
-          - host: foo22.staging.atl-paas.net
-            http:
-              paths:
-              - backend:
-                  serviceName: ingress2--service
-                  servicePort: 8080
-                path: /
-  - name: i11--instance
-    references:
-    - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress1-metadata-endpoint
-      path: metadata.annotations['atlassian\.com/ingress\.endpoint']
-      resource: ingress1
-    spec:
-      object:
-        apiVersion: servicecatalog.k8s.io/v1beta1
-        kind: ServiceInstance
-        metadata:
-          name: i11
-        spec:
-          clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
-          clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
-          parameters:
-            aliases:
-            - name: foo11.staging.atl-paas.net
-              type: Simple
-            environmentType: testenv
-            serviceName: test-servicename
-            target: '!{ingress1-metadata-endpoint}'
-  - name: i12--instance
-    references:
-    - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress1-metadata-endpoint
-      path: metadata.annotations['atlassian\.com/ingress\.endpoint']
-      resource: ingress1
-    spec:
-      object:
-        apiVersion: servicecatalog.k8s.io/v1beta1
-        kind: ServiceInstance
-        metadata:
-          name: i12
-        spec:
-          clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
-          clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
-          parameters:
-            aliases:
-            - name: foo12.staging.atl-paas.net
-              type: Simple
-            environmentType: testenv
-            serviceName: test-servicename
-            target: '!{ingress1-metadata-endpoint}'
-  - name: i21--instance
-    references:
-    - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress2-metadata-endpoint
-      path: metadata.annotations['atlassian\.com/ingress\.endpoint']
-      resource: ingress2
-    spec:
-      object:
-        apiVersion: servicecatalog.k8s.io/v1beta1
-        kind: ServiceInstance
-        metadata:
-          name: i21
-        spec:
-          clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
-          clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
-          parameters:
-            aliases:
-            - name: foo21.staging.atl-paas.net
-              type: Simple
-            environmentType: testenv
-            serviceName: test-servicename
-            target: '!{ingress2-metadata-endpoint}'
-  - name: i22--instance
-    references:
-    - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress2-metadata-endpoint
-      path: metadata.annotations['atlassian\.com/ingress\.endpoint']
-      resource: ingress2
-    spec:
-      object:
-        apiVersion: servicecatalog.k8s.io/v1beta1
-        kind: ServiceInstance
-        metadata:
-          name: i22
-        spec:
-          clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
-          clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
-          parameters:
-            aliases:
-            - name: foo22.staging.atl-paas.net
-              type: Simple
-            environmentType: testenv
-            serviceName: test-servicename
-            target: '!{ingress2-metadata-endpoint}'
+          maxReplicas: 10
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 50
+            type: Resource
+          - resource:
+              name: memory
+              targetAverageValue: 50Mi
+            type: Resource
+          minReplicas: 2
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: '!{c2-metadata-name}'
 status: {}

--- a/pkg/orchestration/wiring/testdata/k8scompute.pdb.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.pdb.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: c1--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 66%
           selector:
             matchLabels:
               resourceName: c1

--- a/pkg/orchestration/wiring/testdata/k8scompute.pdb.state.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.pdb.state.yaml
@@ -1,0 +1,116 @@
+apiVersion: orchestration.voyager.atl-paas.net/v1
+kind: State
+metadata:
+  name: state1
+  namespace: default123
+  uid: 411c0040-617e-11e7-9b57-427d691976d7
+spec:
+  resources:
+  - type: KubeCompute
+    name: c1
+    defaults:
+      filledInBy: "Formation layer"
+      replicas: 5
+      Scaling:
+        MinReplicas: 5
+        MaxReplicas: 10
+        Metrics:
+        - Type: Resource
+          Resource:
+            Name: cpu
+            TargetAverageUtilization: 80
+      Container:
+        ImagePullPolicy: IfNotPresent
+        Resources:
+          Requests:
+            cpu: 50m
+            memory: 50Mi
+          Limits:
+            cpu: 250m
+            memory: 150Mi
+      Port:
+        Protocol: TCP
+    spec:
+      scaling:
+        minReplicas: 5
+        maxReplicas: 10
+        metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            targetAverageUtilization: 50
+        - type: Resource
+          resource:
+            name: memory
+            targetAverageValue: "50Mi"
+      containers:
+        - name: microservice
+          image: "docker.example.com/atlassian/micros-analytics:0.1"
+          ports:
+          - containerPort: 8080
+          resources:
+            requests:
+                memory: "64Mi"
+                cpu: "250m"
+            limits:
+                memory: "128Mi"
+                cpu: "500m"
+        - name: pgbouncer
+          image: "docker.example.com/my_pgbouncer:abcxyz"
+          ports:
+          - containerPort: 5432
+            protocol: UDP
+  - type: KubeCompute
+    name: c2
+    defaults:
+      filledInBy: "Formation layer"
+      replicas: 2
+      Scaling:
+        MinReplicas: 2
+        MaxReplicas: 10
+        Metrics:
+        - Type: Resource
+          Resource:
+            Name: cpu
+            TargetAverageUtilization: 80
+      Container:
+        ImagePullPolicy: IfNotPresent
+        Resources:
+          Requests:
+            cpu: 50m
+            memory: 50Mi
+          Limits:
+            cpu: 250m
+            memory: 150Mi
+      Port:
+        Protocol: TCP
+    spec:
+      scaling:
+        minReplicas: 2
+        maxReplicas: 10
+        metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            targetAverageUtilization: 50
+        - type: Resource
+          resource:
+            name: memory
+            targetAverageValue: "50Mi"
+      containers:
+        - name: microservice
+          image: "docker.example.com/atlassian/micros-analytics:0.1"
+          ports:
+          - containerPort: 8080
+          resources:
+            requests:
+                memory: "64Mi"
+                cpu: "250m"
+            limits:
+                memory: "128Mi"
+                cpu: "500m"
+        - name: pgbouncer
+          image: "docker.example.com/my_pgbouncer:abcxyz"
+          ports:
+          - containerPort: 5432
+            protocol: UDP

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
@@ -172,7 +172,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 66%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/platformdns.multiplealias.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.multiplealias.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/platformdns.multiplealias.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.multiplealias.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: kubecompute-simple--pdb
         spec:
-          minAvailable: 30%
+          minAvailable: 100%
           selector:
             matchLabels:
               resourceName: kubecompute-simple

--- a/pkg/orchestration/wiring/testdata/platformdns.multipleresources.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.multipleresources.bundle.yaml
@@ -30,7 +30,7 @@ spec:
         metadata:
           name: c1--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: c1
@@ -149,7 +149,7 @@ spec:
         metadata:
           name: c2--pdb
         spec:
-          minAvailable: 100%
+          minAvailable: 0%
           selector:
             matchLabels:
               resourceName: c2


### PR DESCRIPTION
If there are < 3 replicas, the kubecompute pod disruption budget must be raised accordingly to prevent node drain issues.