### PR TITLE
VYGR-461: Deprecate SvcCatEntangler

### DIFF
--- a/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
+++ b/pkg/orchestration/wiring/wiringutil/svccatentangler/plugin.go
@@ -26,6 +26,8 @@ type ShapesFunc func(resource *orch_v1.StateResource, smithResource *smith_v1.Re
 // list of smith references through References().
 //
 // This is for WiringPlugins that will create a ServiceInstance.
+
+// DEPRECATED: Use helper functions from 'osb' package instead.
 type SvcCatEntangler struct {
 
 	// This identifies what resource types can be processed.


### PR DESCRIPTION
I would delete it straight away, as nothing in master depend on it, but there are several PRs in progress still using SvcCatEntangler and I don't want to break them.