### PR TITLE
NONE: Fixed panic case in SC client

### DIFF
--- a/pkg/servicecentral/store.go
+++ b/pkg/servicecentral/store.go
@@ -181,7 +181,15 @@ func (c *Store) getServiceDataByUUID(ctx context.Context, user auth.OptionalUser
 		if httputil.IsNotFound(err) {
 			return nil, NewNotFound("service with uuid %q was not found", uuid)
 		}
-		return nil, errors.Wrapf(err, "error getting service %q", data.ServiceName)
+
+		var serviceID string
+		if data != nil {
+			serviceID = fmt.Sprintf("name=%q", data.ServiceName)
+		} else {
+			serviceID = fmt.Sprintf("uuid=%q", uuid)
+		}
+
+		return nil, errors.Wrapf(err, "error getting service %q", serviceID)
 	}
 
 	return data, nil

--- a/pkg/servicecentral/store.go
+++ b/pkg/servicecentral/store.go
@@ -181,15 +181,7 @@ func (c *Store) getServiceDataByUUID(ctx context.Context, user auth.OptionalUser
 		if httputil.IsNotFound(err) {
 			return nil, NewNotFound("service with uuid %q was not found", uuid)
 		}
-
-		var serviceID string
-		if data != nil {
-			serviceID = fmt.Sprintf("name=%q", data.ServiceName)
-		} else {
-			serviceID = fmt.Sprintf("uuid=%q", uuid)
-		}
-
-		return nil, errors.Wrapf(err, "error getting service %q", serviceID)
+		return nil, errors.Wrapf(err, "error getting service %q", uuid)
 	}
 
 	return data, nil


### PR DESCRIPTION
This caused a panic in integration. I think this fixes it.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18f282b]

goroutine 299 [running]:
stash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/pkg/servicecentral.(*Store).getServiceDataByUUID(0xc00059c500, 0x1ec37a0, 0xc00004c018, 0x0, 0xc0010dea80, 0x24, 0xc001d74ee0, 0x1, 0x1)
        vendor/github.com/atlassian/voyager/pkg/servicecentral/store.go:184 +0x1eb
stash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/pkg/servicecentral.(*Store).getServiceDataByName(0xc00059c500, 0x1ec37a0, 0xc00004c018, 0x0, 0xc0010e0ea0, 0xe, 0xc0012659b8, 0x41610b, 0xc000cdd440)
        vendor/github.com/atlassian/voyager/pkg/servicecentral/store.go:170 +0x3ed
stash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/pkg/servicecentral.(*Store).GetService(0xc00059c500, 0x1ec37a0, 0xc00004c018, 0x0, 0xc0010e0ea0, 0xe, 0xc00130f800, 0x0, 0x0)
        vendor/github.com/atlassian/voyager/pkg/servicecentral/store.go:130 +0x7b
stash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/pkg/synchronization.(*Controller).syncServiceMetadata.func1(0xc000c505e0, 0xc000cdd440, 0xc0001c6000)
        vendor/github.com/atlassian/voyager/pkg/synchronization/controller.go:340 +0x1e1
created by stash.atlassian.com/micros/voyager/vendor/github.com/atlassian/voyager/pkg/synchronization.(*Controller).syncServiceMetadata
        vendor/github.com/atlassian/voyager/pkg/synchronization/controller.go:334 +0x861
```