### PR TITLE
Cleanup reference construction and usage

### DIFF
--- a/pkg/orchestration/wiring/ec2compute/v2/plugin.go
+++ b/pkg/orchestration/wiring/ec2compute/v2/plugin.go
@@ -317,7 +317,7 @@ func (p *WiringPlugin) wireUp(microServiceNameInSpec, ec2ComputePlanName string,
 		}
 
 		resourceReference := bindableEnvVarShape.Data.ServiceInstanceName
-		bindingResource := wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, resourceReference)
+		bindingResource := wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, resourceReference.ToReference())
 		bindingResources = append(bindingResources, bindingResource)
 		resourcesWithEnvVarBindings = append(resourcesWithEnvVarBindings, compute.ResourceWithEnvVarBinding{
 			ResourceName:        dependency.Name,
@@ -342,7 +342,7 @@ func (p *WiringPlugin) wireUp(microServiceNameInSpec, ec2ComputePlanName string,
 			if iamResourceReference == resourceReference {
 				iamBindingResource = bindingResource
 			} else {
-				iamBindingResource = wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, iamResourceReference)
+				iamBindingResource = wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, iamResourceReference.ToReference())
 				bindingResources = append(bindingResources, iamBindingResource)
 			}
 			resourcesWithIamAccessibleBindings = append(resourcesWithIamAccessibleBindings, iam.ResourceWithIamAccessibleBinding{

--- a/pkg/orchestration/wiring/ec2compute/v2/plugin.go
+++ b/pkg/orchestration/wiring/ec2compute/v2/plugin.go
@@ -316,8 +316,8 @@ func (p *WiringPlugin) wireUp(microServiceNameInSpec, ec2ComputePlanName string,
 			}
 		}
 
-		resourceReference := bindableEnvVarShape.Data.ServiceInstanceName
-		bindingResource := wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, resourceReference.ToReference())
+		resourceReference := bindableEnvVarShape.Data.ServiceInstanceName.ToReference()
+		bindingResource := wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, resourceReference)
 		bindingResources = append(bindingResources, bindingResource)
 		resourcesWithEnvVarBindings = append(resourcesWithEnvVarBindings, compute.ResourceWithEnvVarBinding{
 			ResourceName:        dependency.Name,
@@ -335,19 +335,20 @@ func (p *WiringPlugin) wireUp(microServiceNameInSpec, ec2ComputePlanName string,
 			}
 		}
 		if iamFound {
-			var iamBindingResource smith_v1.Resource
-			iamResourceReference := bindableIamAccessibleShape.Data.ServiceInstanceName
-			// Reuse the binding if the service instance name is the same, otherwise
+			var iamBindingResourceName smith_v1.ResourceName
+			iamResourceReference := bindableIamAccessibleShape.Data.ServiceInstanceName.ToReference()
+			// Reuse the binding if the service instance name reference is the same, otherwise
 			// we'll need to do another binding
-			if iamResourceReference == resourceReference {
-				iamBindingResource = bindingResource
+			if wiringutil.IsSameTarget(iamResourceReference, resourceReference) {
+				iamBindingResourceName = bindingResource.Name
 			} else {
-				iamBindingResource = wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, iamResourceReference.ToReference())
+				iamBindingResource := wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, iamResourceReference)
 				bindingResources = append(bindingResources, iamBindingResource)
+				iamBindingResourceName = iamBindingResource.Name
 			}
 			resourcesWithIamAccessibleBindings = append(resourcesWithIamAccessibleBindings, iam.ResourceWithIamAccessibleBinding{
 				ResourceName:               dependency.Name,
-				BindingName:                iamBindingResource.Name,
+				BindingName:                iamBindingResourceName,
 				BindableIamAccessibleShape: *bindableIamAccessibleShape,
 			})
 		}

--- a/pkg/orchestration/wiring/k8scompute/plugin.go
+++ b/pkg/orchestration/wiring/k8scompute/plugin.go
@@ -170,8 +170,8 @@ func (p *WiringPlugin) WireUp(resource *orch_v1.StateResource, context *wiringpl
 			}
 		}
 
-		resourceReference := bindableEnvVarShape.Data.ServiceInstanceName
-		binding := wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, resourceReference.ToReference())
+		resourceReference := bindableEnvVarShape.Data.ServiceInstanceName.ToReference()
+		binding := wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, resourceReference)
 		smithResources = append(smithResources, binding)
 		resourceWithEnvVarBindings = append(resourceWithEnvVarBindings, compute.ResourceWithEnvVarBinding{
 			ResourceName:        dep.Name,
@@ -188,19 +188,20 @@ func (p *WiringPlugin) WireUp(resource *orch_v1.StateResource, context *wiringpl
 			}
 		}
 		if iamFound {
-			var iamBindingResource smith_v1.Resource
-			iamResourceReference := bindableIamAccessibleShape.Data.ServiceInstanceName
-			// Reuse the binding if the service instance name is the same, otherwise
+			var iamBindingResourceName smith_v1.ResourceName
+			iamResourceReference := bindableIamAccessibleShape.Data.ServiceInstanceName.ToReference()
+			// Reuse the binding if the service instance name reference is the same, otherwise
 			// we'll need to do another binding
-			if iamResourceReference == resourceReference {
-				iamBindingResource = binding
+			if wiringutil.IsSameTarget(iamResourceReference, resourceReference) {
+				iamBindingResourceName = binding.Name
 			} else {
-				iamBindingResource = wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, iamResourceReference.ToReference())
+				iamBindingResource := wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, iamResourceReference)
 				smithResources = append(smithResources, iamBindingResource)
+				iamBindingResourceName = iamBindingResource.Name
 			}
 			resourcesWithIamAccessibleBindings = append(resourcesWithIamAccessibleBindings, iam.ResourceWithIamAccessibleBinding{
 				ResourceName:               dep.Name,
-				BindingName:                iamBindingResource.Name,
+				BindingName:                iamBindingResourceName,
 				BindableIamAccessibleShape: *bindableIamAccessibleShape,
 			})
 		}

--- a/pkg/orchestration/wiring/k8scompute/plugin.go
+++ b/pkg/orchestration/wiring/k8scompute/plugin.go
@@ -171,7 +171,7 @@ func (p *WiringPlugin) WireUp(resource *orch_v1.StateResource, context *wiringpl
 		}
 
 		resourceReference := bindableEnvVarShape.Data.ServiceInstanceName
-		binding := wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, resourceReference)
+		binding := wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, resourceReference.ToReference())
 		smithResources = append(smithResources, binding)
 		resourceWithEnvVarBindings = append(resourceWithEnvVarBindings, compute.ResourceWithEnvVarBinding{
 			ResourceName:        dep.Name,
@@ -195,7 +195,7 @@ func (p *WiringPlugin) WireUp(resource *orch_v1.StateResource, context *wiringpl
 			if iamResourceReference == resourceReference {
 				iamBindingResource = binding
 			} else {
-				iamBindingResource = wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, iamResourceReference)
+				iamBindingResource = wiringutil.ConsumerProducerServiceBinding(resource.Name, dep.Name, iamResourceReference.ToReference())
 				smithResources = append(smithResources, iamBindingResource)
 			}
 			resourcesWithIamAccessibleBindings = append(resourcesWithIamAccessibleBindings, iam.ResourceWithIamAccessibleBinding{

--- a/pkg/orchestration/wiring/platformdns/plugin.go
+++ b/pkg/orchestration/wiring/platformdns/plugin.go
@@ -16,11 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	kubeIngressRefMetadata         = "metadata"
-	kubeIngressRefMetadataEndpoint = "endpoint"
-)
-
 type autowiringOnlySpec struct {
 	Target          string              `json:"target"`
 	ServiceName     voyager.ServiceName `json:"serviceName"`
@@ -158,8 +153,6 @@ func getReferences(_ *orch_v1.StateResource, context *wiringplugin.WiringContext
 		return nil, true, false, errors.Errorf("shape %q is required to create ServiceBinding for %q but was not found",
 			knownshapes.IngressEndpointShape, dependency.Name)
 	}
-	ingressEndpoint := ingressShape.Data.IngressEndpoint
-	referenceName := wiringutil.ReferenceName(ingressEndpoint.Resource, kubeIngressRefMetadata, kubeIngressRefMetadataEndpoint)
-	references = append(references, ingressEndpoint.ToReference(referenceName))
+	references = append(references, ingressShape.Data.IngressEndpoint.ToReference())
 	return references, false, false, nil
 }

--- a/pkg/orchestration/wiring/sqs/plugin.go
+++ b/pkg/orchestration/wiring/sqs/plugin.go
@@ -21,8 +21,6 @@ const (
 	ResourceType   voyager.ResourceType = "SQS"
 	ResourcePrefix                      = "SQS"
 
-	snsTopicArnReferenceNameSuffix = "TopicArn"
-
 	clusterServiceClassExternalName = "sqs"
 	clusterServiceClassExternalID   = "06068066-7f66-4297-8683-a1ba0a2b7401"
 	clusterServicePlanExternalID    = "56393d2c-d936-4634-a178-19f491a3551a"
@@ -68,12 +66,10 @@ func WireUp(stateResource *orch_v1.StateResource, context *wiringplugin.WiringCo
 				IsExternalError: true,
 			}
 		}
-		resourceRef := snsShape.Data.ServiceInstanceName
-		serviceBinding := wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, resourceRef)
+		serviceBinding := wiringutil.ConsumerProducerServiceBinding(stateResource.Name, dependency.Name, snsShape.Data.ServiceInstanceName.ToReference())
 		wiredResources = append(wiredResources, serviceBinding)
 
-		referenceName := wiringutil.ReferenceName(serviceBinding.Name, snsTopicArnReferenceNameSuffix)
-		topicArnRef := snsShape.Data.TopicARN.ToReference(referenceName, serviceBinding.Name)
+		topicArnRef := snsShape.Data.TopicARN.ToReference(serviceBinding.Name)
 		references = append(references, topicArnRef)
 		snsSubscriptions = append(snsSubscriptions, snsSubscription{
 			TopicArn:   topicArnRef.Ref(),

--- a/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
@@ -30,7 +30,7 @@ spec:
   - name: kubecompute-simple--asap--binding
     references:
     - example: aname
-      name: asap--instance-metadata-name
+      name: asap--instance
       path: metadata.name
       resource: asap--instance
     spec:
@@ -41,7 +41,7 @@ spec:
           name: kubecompute-simple--asap
         spec:
           instanceRef:
-            name: '!{asap--instance-metadata-name}'
+            name: '!{asap--instance}'
           secretName: kubecompute-simple--asap
   - name: kubecompute-simple--secret
     references:

--- a/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
@@ -114,7 +114,7 @@ spec:
   - name: notification-sqs--notification-sns--binding
     references:
     - example: aname
-      name: notification-sns--instance-metadata-name
+      name: notification-sns--instance
       path: metadata.name
       resource: notification-sns--instance
     spec:
@@ -125,13 +125,13 @@ spec:
           name: notification-sqs--notification-sns
         spec:
           instanceRef:
-            name: '!{notification-sns--instance-metadata-name}'
+            name: '!{notification-sns--instance}'
           secretName: notification-sqs--notification-sns
   - name: notification-sqs--instance
     references:
     - example: '"arn:aws:sns:us-east-1:123456789012:example"'
       modifier: bindsecret
-      name: notification-sqs--notification-sns--binding-TopicArn
+      name: notification-sqs--notification-sns--binding-topicArn
       path: data.TopicArn
       resource: notification-sqs--notification-sns--binding
     spec:
@@ -167,7 +167,7 @@ spec:
                 Subscriptions:
                 - attributes:
                     RawMessageDelivery: false
-                  topicArn: '!{notification-sqs--notification-sns--binding-TopicArn}'
+                  topicArn: '!{notification-sqs--notification-sns--binding-topicArn}'
                 VisibilityTimeout: 30
               name: notification-sqs
               type: sqs
@@ -365,7 +365,7 @@ spec:
   - name: ec2--asap--binding
     references:
     - example: aname
-      name: asap--instance-metadata-name
+      name: asap--instance
       path: metadata.name
       resource: asap--instance
     spec:
@@ -376,12 +376,12 @@ spec:
           name: ec2--asap
         spec:
           instanceRef:
-            name: '!{asap--instance-metadata-name}'
+            name: '!{asap--instance}'
           secretName: ec2--asap
   - name: ec2--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -392,12 +392,12 @@ spec:
           name: ec2--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: ec2--basic
   - name: ec2--files--binding
     references:
     - example: aname
-      name: files--instance-metadata-name
+      name: files--instance
       path: metadata.name
       resource: files--instance
     spec:
@@ -408,12 +408,12 @@ spec:
           name: ec2--files
         spec:
           instanceRef:
-            name: '!{files--instance-metadata-name}'
+            name: '!{files--instance}'
           secretName: ec2--files
   - name: ec2--stream--binding
     references:
     - example: aname
-      name: stream--instance-metadata-name
+      name: stream--instance
       path: metadata.name
       resource: stream--instance
     spec:
@@ -424,12 +424,12 @@ spec:
           name: ec2--stream
         spec:
           instanceRef:
-            name: '!{stream--instance-metadata-name}'
+            name: '!{stream--instance}'
           secretName: ec2--stream
   - name: ec2--dynamo-basic--binding
     references:
     - example: aname
-      name: dynamo-basic--instance-metadata-name
+      name: dynamo-basic--instance
       path: metadata.name
       resource: dynamo-basic--instance
     spec:
@@ -440,12 +440,12 @@ spec:
           name: ec2--dynamo-basic
         spec:
           instanceRef:
-            name: '!{dynamo-basic--instance-metadata-name}'
+            name: '!{dynamo-basic--instance}'
           secretName: ec2--dynamo-basic
   - name: ec2--dynamo-complex--binding
     references:
     - example: aname
-      name: dynamo-complex--instance-metadata-name
+      name: dynamo-complex--instance
       path: metadata.name
       resource: dynamo-complex--instance
     spec:
@@ -456,12 +456,12 @@ spec:
           name: ec2--dynamo-complex
         spec:
           instanceRef:
-            name: '!{dynamo-complex--instance-metadata-name}'
+            name: '!{dynamo-complex--instance}'
           secretName: ec2--dynamo-complex
   - name: ec2--datastore--binding
     references:
     - example: aname
-      name: datastore--instance-metadata-name
+      name: datastore--instance
       path: metadata.name
       resource: datastore--instance
     spec:
@@ -472,12 +472,12 @@ spec:
           name: ec2--datastore
         spec:
           instanceRef:
-            name: '!{datastore--instance-metadata-name}'
+            name: '!{datastore--instance}'
           secretName: ec2--datastore
   - name: ec2--notification-sns--binding
     references:
     - example: aname
-      name: notification-sns--instance-metadata-name
+      name: notification-sns--instance
       path: metadata.name
       resource: notification-sns--instance
     spec:
@@ -488,12 +488,12 @@ spec:
           name: ec2--notification-sns
         spec:
           instanceRef:
-            name: '!{notification-sns--instance-metadata-name}'
+            name: '!{notification-sns--instance}'
           secretName: ec2--notification-sns
   - name: ec2--notification-sqs--binding
     references:
     - example: aname
-      name: notification-sqs--instance-metadata-name
+      name: notification-sqs--instance
       path: metadata.name
       resource: notification-sqs--instance
     spec:
@@ -504,7 +504,7 @@ spec:
           name: ec2--notification-sqs
         spec:
           instanceRef:
-            name: '!{notification-sqs--instance-metadata-name}'
+            name: '!{notification-sqs--instance}'
           secretName: ec2--notification-sqs
   - name: ec2--secret
     references:
@@ -719,31 +719,31 @@ spec:
   - name: ec2---iamrole
     references:
     - modifier: bindsecret
-      name: ec2--basic--binding-iamrole
+      name: ec2--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: ec2--basic--binding
     - modifier: bindsecret
-      name: ec2--files--binding-iamrole
+      name: ec2--files--binding-policySnippet
       path: data.IamPolicySnippet
       resource: ec2--files--binding
     - modifier: bindsecret
-      name: ec2--stream--binding-iamrole
+      name: ec2--stream--binding-policySnippet
       path: data.IamPolicySnippet
       resource: ec2--stream--binding
     - modifier: bindsecret
-      name: ec2--dynamo-basic--binding-iamrole
+      name: ec2--dynamo-basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: ec2--dynamo-basic--binding
     - modifier: bindsecret
-      name: ec2--dynamo-complex--binding-iamrole
+      name: ec2--dynamo-complex--binding-policySnippet
       path: data.IamPolicySnippet
       resource: ec2--dynamo-complex--binding
     - modifier: bindsecret
-      name: ec2--notification-sns--binding-iamrole
+      name: ec2--notification-sns--binding-policySnippet
       path: data.IamPolicySnippet
       resource: ec2--notification-sns--binding
     - modifier: bindsecret
-      name: ec2--notification-sqs--binding-iamrole
+      name: ec2--notification-sqs--binding-policySnippet
       path: data.IamPolicySnippet
       resource: ec2--notification-sqs--binding
     spec:
@@ -760,13 +760,13 @@ spec:
           - arn:aws:iam::123456789012:policy/micros-iam-DefaultServicePolicy-ABC
           oapResourceName: ec2-iamrole
           policySnippets:
-            basic: '!{ec2--basic--binding-iamrole}'
-            dynamo-basic: '!{ec2--dynamo-basic--binding-iamrole}'
-            dynamo-complex: '!{ec2--dynamo-complex--binding-iamrole}'
-            files: '!{ec2--files--binding-iamrole}'
-            notification-sns: '!{ec2--notification-sns--binding-iamrole}'
-            notification-sqs: '!{ec2--notification-sqs--binding-iamrole}'
-            stream: '!{ec2--stream--binding-iamrole}'
+            basic: '!{ec2--basic--binding-policySnippet}'
+            dynamo-basic: '!{ec2--dynamo-basic--binding-policySnippet}'
+            dynamo-complex: '!{ec2--dynamo-complex--binding-policySnippet}'
+            files: '!{ec2--files--binding-policySnippet}'
+            notification-sns: '!{ec2--notification-sns--binding-policySnippet}'
+            notification-sqs: '!{ec2--notification-sqs--binding-policySnippet}'
+            stream: '!{ec2--stream--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty
@@ -888,7 +888,7 @@ spec:
   - name: kc--asap--binding
     references:
     - example: aname
-      name: asap--instance-metadata-name
+      name: asap--instance
       path: metadata.name
       resource: asap--instance
     spec:
@@ -899,12 +899,12 @@ spec:
           name: kc--asap
         spec:
           instanceRef:
-            name: '!{asap--instance-metadata-name}'
+            name: '!{asap--instance}'
           secretName: kc--asap
   - name: kc--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -915,12 +915,12 @@ spec:
           name: kc--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: kc--basic
   - name: kc--files--binding
     references:
     - example: aname
-      name: files--instance-metadata-name
+      name: files--instance
       path: metadata.name
       resource: files--instance
     spec:
@@ -931,12 +931,12 @@ spec:
           name: kc--files
         spec:
           instanceRef:
-            name: '!{files--instance-metadata-name}'
+            name: '!{files--instance}'
           secretName: kc--files
   - name: kc--stream--binding
     references:
     - example: aname
-      name: stream--instance-metadata-name
+      name: stream--instance
       path: metadata.name
       resource: stream--instance
     spec:
@@ -947,12 +947,12 @@ spec:
           name: kc--stream
         spec:
           instanceRef:
-            name: '!{stream--instance-metadata-name}'
+            name: '!{stream--instance}'
           secretName: kc--stream
   - name: kc--dynamo-basic--binding
     references:
     - example: aname
-      name: dynamo-basic--instance-metadata-name
+      name: dynamo-basic--instance
       path: metadata.name
       resource: dynamo-basic--instance
     spec:
@@ -963,12 +963,12 @@ spec:
           name: kc--dynamo-basic
         spec:
           instanceRef:
-            name: '!{dynamo-basic--instance-metadata-name}'
+            name: '!{dynamo-basic--instance}'
           secretName: kc--dynamo-basic
   - name: kc--dynamo-complex--binding
     references:
     - example: aname
-      name: dynamo-complex--instance-metadata-name
+      name: dynamo-complex--instance
       path: metadata.name
       resource: dynamo-complex--instance
     spec:
@@ -979,12 +979,12 @@ spec:
           name: kc--dynamo-complex
         spec:
           instanceRef:
-            name: '!{dynamo-complex--instance-metadata-name}'
+            name: '!{dynamo-complex--instance}'
           secretName: kc--dynamo-complex
   - name: kc--datastore--binding
     references:
     - example: aname
-      name: datastore--instance-metadata-name
+      name: datastore--instance
       path: metadata.name
       resource: datastore--instance
     spec:
@@ -995,12 +995,12 @@ spec:
           name: kc--datastore
         spec:
           instanceRef:
-            name: '!{datastore--instance-metadata-name}'
+            name: '!{datastore--instance}'
           secretName: kc--datastore
   - name: kc--notification-sns--binding
     references:
     - example: aname
-      name: notification-sns--instance-metadata-name
+      name: notification-sns--instance
       path: metadata.name
       resource: notification-sns--instance
     spec:
@@ -1011,12 +1011,12 @@ spec:
           name: kc--notification-sns
         spec:
           instanceRef:
-            name: '!{notification-sns--instance-metadata-name}'
+            name: '!{notification-sns--instance}'
           secretName: kc--notification-sns
   - name: kc--notification-sqs--binding
     references:
     - example: aname
-      name: notification-sqs--instance-metadata-name
+      name: notification-sqs--instance
       path: metadata.name
       resource: notification-sqs--instance
     spec:
@@ -1027,7 +1027,7 @@ spec:
           name: kc--notification-sqs
         spec:
           instanceRef:
-            name: '!{notification-sqs--instance-metadata-name}'
+            name: '!{notification-sqs--instance}'
           secretName: kc--notification-sqs
   - name: kc--secret
     references:
@@ -1240,31 +1240,31 @@ spec:
   - name: kc---iamrole
     references:
     - modifier: bindsecret
-      name: kc--basic--binding-iamrole
+      name: kc--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kc--basic--binding
     - modifier: bindsecret
-      name: kc--files--binding-iamrole
+      name: kc--files--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kc--files--binding
     - modifier: bindsecret
-      name: kc--stream--binding-iamrole
+      name: kc--stream--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kc--stream--binding
     - modifier: bindsecret
-      name: kc--dynamo-basic--binding-iamrole
+      name: kc--dynamo-basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kc--dynamo-basic--binding
     - modifier: bindsecret
-      name: kc--dynamo-complex--binding-iamrole
+      name: kc--dynamo-complex--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kc--dynamo-complex--binding
     - modifier: bindsecret
-      name: kc--notification-sns--binding-iamrole
+      name: kc--notification-sns--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kc--notification-sns--binding
     - modifier: bindsecret
-      name: kc--notification-sqs--binding-iamrole
+      name: kc--notification-sqs--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kc--notification-sqs--binding
     spec:
@@ -1278,13 +1278,13 @@ spec:
           computeType: kubeCompute
           oapResourceName: kc-iamrole
           policySnippets:
-            basic: '!{kc--basic--binding-iamrole}'
-            dynamo-basic: '!{kc--dynamo-basic--binding-iamrole}'
-            dynamo-complex: '!{kc--dynamo-complex--binding-iamrole}'
-            files: '!{kc--files--binding-iamrole}'
-            notification-sns: '!{kc--notification-sns--binding-iamrole}'
-            notification-sqs: '!{kc--notification-sqs--binding-iamrole}'
-            stream: '!{kc--stream--binding-iamrole}'
+            basic: '!{kc--basic--binding-policySnippet}'
+            dynamo-basic: '!{kc--dynamo-basic--binding-policySnippet}'
+            dynamo-complex: '!{kc--dynamo-complex--binding-policySnippet}'
+            files: '!{kc--files--binding-policySnippet}'
+            notification-sns: '!{kc--notification-sns--binding-policySnippet}'
+            notification-sqs: '!{kc--notification-sqs--binding-policySnippet}'
+            stream: '!{kc--stream--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/ec2compute-rename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/ec2compute-rename.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: compute--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: compute--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: compute--basic
   - name: compute--secret
     references:
@@ -94,7 +94,7 @@ spec:
   - name: compute---iamrole
     references:
     - modifier: bindsecret
-      name: compute--basic--binding-iamrole
+      name: compute--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: compute--basic--binding
     spec:
@@ -111,7 +111,7 @@ spec:
           - arn:aws:iam::123456789012:policy/micros-iam-DefaultServicePolicy-ABC
           oapResourceName: compute-iamrole
           policySnippets:
-            basic: '!{compute--basic--binding-iamrole}'
+            basic: '!{compute--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/ec2compute.asapkey.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/ec2compute.asapkey.bundle.yaml
@@ -30,7 +30,7 @@ spec:
   - name: compute--myasap--binding
     references:
     - example: aname
-      name: myasap--instance-metadata-name
+      name: myasap--instance
       path: metadata.name
       resource: myasap--instance
     spec:
@@ -41,7 +41,7 @@ spec:
           name: compute--myasap
         spec:
           instanceRef:
-            name: '!{myasap--instance-metadata-name}'
+            name: '!{myasap--instance}'
           secretName: compute--myasap
   - name: compute--secret
     references:

--- a/pkg/orchestration/wiring/testdata/ec2compute.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/ec2compute.basicdep.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: compute--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: compute--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: compute--basic
   - name: compute--secret
     references:
@@ -94,7 +94,7 @@ spec:
   - name: compute---iamrole
     references:
     - modifier: bindsecret
-      name: compute--basic--binding-iamrole
+      name: compute--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: compute--basic--binding
     spec:
@@ -111,7 +111,7 @@ spec:
           - arn:aws:iam::123456789012:policy/micros-iam-DefaultServicePolicy-ABC
           oapResourceName: compute-iamrole
           policySnippets:
-            basic: '!{compute--basic--binding-iamrole}'
+            basic: '!{compute--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/ec2compute.customrdsreplica.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/ec2compute.customrdsreplica.bundle.yaml
@@ -89,7 +89,7 @@ spec:
   - name: compute--db--binding
     references:
     - example: aname
-      name: db--instance-metadata-name
+      name: db--instance
       path: metadata.name
       resource: db--instance
     spec:
@@ -100,7 +100,7 @@ spec:
           name: compute--db
         spec:
           instanceRef:
-            name: '!{db--instance-metadata-name}'
+            name: '!{db--instance}'
           secretName: compute--db
   - name: compute--secret
     references:

--- a/pkg/orchestration/wiring/testdata/ec2compute.rds.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/ec2compute.rds.bundle.yaml
@@ -88,7 +88,7 @@ spec:
   - name: compute--db--binding
     references:
     - example: aname
-      name: db--instance-metadata-name
+      name: db--instance
       path: metadata.name
       resource: db--instance
     spec:
@@ -99,7 +99,7 @@ spec:
           name: compute--db
         spec:
           instanceRef:
-            name: '!{db--instance-metadata-name}'
+            name: '!{db--instance}'
           secretName: compute--db
   - name: compute--secret
     references:

--- a/pkg/orchestration/wiring/testdata/ec2compute.withcustomups.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/ec2compute.withcustomups.bundle.yaml
@@ -29,7 +29,7 @@ spec:
   - name: compute--ups--binding
     references:
     - example: aname
-      name: ups--instance-metadata-name
+      name: ups--instance
       path: metadata.name
       resource: ups--instance
     spec:
@@ -40,7 +40,7 @@ spec:
           name: compute--ups
         spec:
           instanceRef:
-            name: '!{ups--instance-metadata-name}'
+            name: '!{ups--instance}'
           secretName: compute--ups
   - name: compute--secret
     references:

--- a/pkg/orchestration/wiring/testdata/ec2compute.withups.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/ec2compute.withups.bundle.yaml
@@ -26,7 +26,7 @@ spec:
   - name: compute--ups--binding
     references:
     - example: aname
-      name: ups--instance-metadata-name
+      name: ups--instance
       path: metadata.name
       resource: ups--instance
     spec:
@@ -37,7 +37,7 @@ spec:
           name: compute--ups
         spec:
           instanceRef:
-            name: '!{ups--instance-metadata-name}'
+            name: '!{ups--instance}'
           secretName: compute--ups
   - name: compute--secret
     references:

--- a/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: kubecompute-simple--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: kubecompute-simple--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: kubecompute-simple--basic
   - name: kubecompute-simple--secret
     references:
@@ -92,7 +92,7 @@ spec:
   - name: kubecompute-simple---iamrole
     references:
     - modifier: bindsecret
-      name: kubecompute-simple--basic--binding-iamrole
+      name: kubecompute-simple--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kubecompute-simple--basic--binding
     spec:
@@ -106,7 +106,7 @@ spec:
           computeType: kubeCompute
           oapResourceName: kubecompute-simple-iamrole
           policySnippets:
-            basic: '!{kubecompute-simple--basic--binding-iamrole}'
+            basic: '!{kubecompute-simple--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: kubecompute-simple--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: kubecompute-simple--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: kubecompute-simple--basic
   - name: kubecompute-simple--secret
     references:
@@ -92,7 +92,7 @@ spec:
   - name: kubecompute-simple---iamrole
     references:
     - modifier: bindsecret
-      name: kubecompute-simple--basic--binding-iamrole
+      name: kubecompute-simple--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kubecompute-simple--basic--binding
     spec:
@@ -106,7 +106,7 @@ spec:
           computeType: kubeCompute
           oapResourceName: kubecompute-simple-iamrole
           policySnippets:
-            basic: '!{kubecompute-simple--basic--binding-iamrole}'
+            basic: '!{kubecompute-simple--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: kubecompute-simple--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: kubecompute-simple--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: kubecompute-simple--basic
   - name: kubecompute-simple--secret
     references:
@@ -92,7 +92,7 @@ spec:
   - name: kubecompute-simple---iamrole
     references:
     - modifier: bindsecret
-      name: kubecompute-simple--basic--binding-iamrole
+      name: kubecompute-simple--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kubecompute-simple--basic--binding
     spec:
@@ -106,7 +106,7 @@ spec:
           computeType: kubeCompute
           oapResourceName: kubecompute-simple-iamrole
           policySnippets:
-            basic: '!{kubecompute-simple--basic--binding-iamrole}'
+            basic: '!{kubecompute-simple--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: kubecompute-simple--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: kubecompute-simple--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: kubecompute-simple--basic
   - name: kubecompute-simple--secret
     references:
@@ -92,7 +92,7 @@ spec:
   - name: kubecompute-simple---iamrole
     references:
     - modifier: bindsecret
-      name: kubecompute-simple--basic--binding-iamrole
+      name: kubecompute-simple--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kubecompute-simple--basic--binding
     spec:
@@ -106,7 +106,7 @@ spec:
           computeType: kubeCompute
           oapResourceName: kubecompute-simple-iamrole
           policySnippets:
-            basic: '!{kubecompute-simple--basic--binding-iamrole}'
+            basic: '!{kubecompute-simple--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: kubecompute-simple--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: kubecompute-simple--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: kubecompute-simple--basic
   - name: kubecompute-simple--secret
     references:
@@ -92,7 +92,7 @@ spec:
   - name: kubecompute-simple---iamrole
     references:
     - modifier: bindsecret
-      name: kubecompute-simple--basic--binding-iamrole
+      name: kubecompute-simple--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kubecompute-simple--basic--binding
     spec:
@@ -106,7 +106,7 @@ spec:
           computeType: kubeCompute
           oapResourceName: kubecompute-simple-iamrole
           policySnippets:
-            basic: '!{kubecompute-simple--basic--binding-iamrole}'
+            basic: '!{kubecompute-simple--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
@@ -48,7 +48,7 @@ spec:
   - name: kubecompute-simple--basic--binding
     references:
     - example: aname
-      name: basic--instance-metadata-name
+      name: basic--instance
       path: metadata.name
       resource: basic--instance
     spec:
@@ -59,7 +59,7 @@ spec:
           name: kubecompute-simple--basic
         spec:
           instanceRef:
-            name: '!{basic--instance-metadata-name}'
+            name: '!{basic--instance}'
           secretName: kubecompute-simple--basic
   - name: kubecompute-simple--secret
     references:
@@ -92,7 +92,7 @@ spec:
   - name: kubecompute-simple---iamrole
     references:
     - modifier: bindsecret
-      name: kubecompute-simple--basic--binding-iamrole
+      name: kubecompute-simple--basic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: kubecompute-simple--basic--binding
     spec:
@@ -106,7 +106,7 @@ spec:
           computeType: kubeCompute
           oapResourceName: kubecompute-simple-iamrole
           policySnippets:
-            basic: '!{kubecompute-simple--basic--binding-iamrole}'
+            basic: '!{kubecompute-simple--basic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
@@ -187,7 +187,7 @@ spec:
   - name: platformdns--instance
     references:
     - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress-metadata-endpoint
+      name: ingress-endpoint
       path: metadata.annotations['atlassian\.com/ingress\.endpoint']
       resource: ingress
     spec:
@@ -200,9 +200,9 @@ spec:
           clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
           clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
           parameters:
-            name: foo.staging.atl-paas.net
-            type: Simple
             environmentType: testenv
+            name: foo.staging.atl-paas.net
             serviceName: test-servicename
-            target: '!{ingress-metadata-endpoint}'
+            target: '!{ingress-endpoint}'
+            type: Simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/platformdns.multipleresources.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.multipleresources.bundle.yaml
@@ -372,7 +372,7 @@ spec:
   - name: i11--instance
     references:
     - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress1-metadata-endpoint
+      name: ingress1-endpoint
       path: metadata.annotations['atlassian\.com/ingress\.endpoint']
       resource: ingress1
     spec:
@@ -385,15 +385,15 @@ spec:
           clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
           clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
           parameters:
-            name: foo11.staging.atl-paas.net
-            type: Simple
             environmentType: testenv
+            name: foo11.staging.atl-paas.net
             serviceName: test-servicename
-            target: '!{ingress1-metadata-endpoint}'
+            target: '!{ingress1-endpoint}'
+            type: Simple
   - name: i12--instance
     references:
     - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress1-metadata-endpoint
+      name: ingress1-endpoint
       path: metadata.annotations['atlassian\.com/ingress\.endpoint']
       resource: ingress1
     spec:
@@ -406,15 +406,15 @@ spec:
           clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
           clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
           parameters:
-            name: foo12.staging.atl-paas.net
-            type: Simple
             environmentType: testenv
+            name: foo12.staging.atl-paas.net
             serviceName: test-servicename
-            target: '!{ingress1-metadata-endpoint}'
+            target: '!{ingress1-endpoint}'
+            type: Simple
   - name: i21--instance
     references:
     - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress2-metadata-endpoint
+      name: ingress2-endpoint
       path: metadata.annotations['atlassian\.com/ingress\.endpoint']
       resource: ingress2
     spec:
@@ -427,15 +427,15 @@ spec:
           clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
           clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
           parameters:
-            name: foo21.staging.atl-paas.net
-            type: Simple
             environmentType: testenv
+            name: foo21.staging.atl-paas.net
             serviceName: test-servicename
-            target: '!{ingress2-metadata-endpoint}'
+            target: '!{ingress2-endpoint}'
+            type: Simple
   - name: i22--instance
     references:
     - example: ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net
-      name: ingress2-metadata-endpoint
+      name: ingress2-endpoint
       path: metadata.annotations['atlassian\.com/ingress\.endpoint']
       resource: ingress2
     spec:
@@ -448,9 +448,9 @@ spec:
           clusterServiceClassExternalID: f77e1881-36f3-42ce-9848-7a811b421dd7
           clusterServicePlanExternalID: 0a7b1d18-cf8d-461e-ad24-ee16d3da36d3
           parameters:
-            name: foo22.staging.atl-paas.net
-            type: Simple
             environmentType: testenv
+            name: foo22.staging.atl-paas.net
             serviceName: test-servicename
-            target: '!{ingress2-metadata-endpoint}'
+            target: '!{ingress2-endpoint}'
+            type: Simple
 status: {}

--- a/pkg/orchestration/wiring/testdata/sns.sqs.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/sns.sqs.bundle.yaml
@@ -65,7 +65,7 @@ spec:
   - name: queue1--fanouttopic--binding
     references:
     - example: aname
-      name: fanouttopic--instance-metadata-name
+      name: fanouttopic--instance
       path: metadata.name
       resource: fanouttopic--instance
     spec:
@@ -76,13 +76,13 @@ spec:
           name: queue1--fanouttopic
         spec:
           instanceRef:
-            name: '!{fanouttopic--instance-metadata-name}'
+            name: '!{fanouttopic--instance}'
           secretName: queue1--fanouttopic
   - name: queue1--instance
     references:
     - example: '"arn:aws:sns:us-east-1:123456789012:example"'
       modifier: bindsecret
-      name: queue1--fanouttopic--binding-TopicArn
+      name: queue1--fanouttopic--binding-topicArn
       path: data.TopicArn
       resource: queue1--fanouttopic--binding
     spec:
@@ -117,14 +117,14 @@ spec:
                 Subscriptions:
                 - attributes:
                     RawMessageDelivery: true
-                  topicArn: '!{queue1--fanouttopic--binding-TopicArn}'
+                  topicArn: '!{queue1--fanouttopic--binding-topicArn}'
               name: queue1
               type: sqs
             serviceName: test-servicename
   - name: queue2--fanouttopic--binding
     references:
     - example: aname
-      name: fanouttopic--instance-metadata-name
+      name: fanouttopic--instance
       path: metadata.name
       resource: fanouttopic--instance
     spec:
@@ -135,13 +135,13 @@ spec:
           name: queue2--fanouttopic
         spec:
           instanceRef:
-            name: '!{fanouttopic--instance-metadata-name}'
+            name: '!{fanouttopic--instance}'
           secretName: queue2--fanouttopic
   - name: queue2--instance
     references:
     - example: '"arn:aws:sns:us-east-1:123456789012:example"'
       modifier: bindsecret
-      name: queue2--fanouttopic--binding-TopicArn
+      name: queue2--fanouttopic--binding-topicArn
       path: data.TopicArn
       resource: queue2--fanouttopic--binding
     spec:
@@ -175,14 +175,14 @@ spec:
               attributes:
                 DelaySeconds: 1
                 Subscriptions:
-                - topicArn: '!{queue2--fanouttopic--binding-TopicArn}'
+                - topicArn: '!{queue2--fanouttopic--binding-topicArn}'
               name: queue2
               type: sqs
             serviceName: test-servicename
   - name: compute--fanouttopic--binding
     references:
     - example: aname
-      name: fanouttopic--instance-metadata-name
+      name: fanouttopic--instance
       path: metadata.name
       resource: fanouttopic--instance
     spec:
@@ -193,7 +193,7 @@ spec:
           name: compute--fanouttopic
         spec:
           instanceRef:
-            name: '!{fanouttopic--instance-metadata-name}'
+            name: '!{fanouttopic--instance}'
           secretName: compute--fanouttopic
   - name: compute--secret
     references:
@@ -223,7 +223,7 @@ spec:
   - name: compute---iamrole
     references:
     - modifier: bindsecret
-      name: compute--fanouttopic--binding-iamrole
+      name: compute--fanouttopic--binding-policySnippet
       path: data.IamPolicySnippet
       resource: compute--fanouttopic--binding
     spec:
@@ -240,7 +240,7 @@ spec:
           - arn:aws:iam::123456789012:policy/micros-iam-DefaultServicePolicy-ABC
           oapResourceName: compute-iamrole
           policySnippets:
-            fanouttopic: '!{compute--fanouttopic--binding-iamrole}'
+            fanouttopic: '!{compute--fanouttopic--binding-policySnippet}'
           serviceEnvironment:
             alarmEndpoints:
             - consumer: pagerduty

--- a/pkg/orchestration/wiring/wiringutil/BUILD.bazel
+++ b/pkg/orchestration/wiring/wiringutil/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//:go_default_library",
         "//pkg/apis/orchestration/v1:go_default_library",
         "//pkg/orchestration/wiring/wiringplugin:go_default_library",
-        "//pkg/orchestration/wiring/wiringutil/libshapes:go_default_library",
         "//vendor/github.com/atlassian/ctrl/apis/condition/v1:go_default_library",
         "//vendor/github.com/atlassian/smith/pkg/apis/smith/v1:go_default_library",
         "//vendor/github.com/imdario/mergo:go_default_library",

--- a/pkg/orchestration/wiring/wiringutil/iam/iam.go
+++ b/pkg/orchestration/wiring/wiringutil/iam/iam.go
@@ -29,9 +29,6 @@ const (
 	// See how meta names would clash if Resource Y was named "iamrole" if there was no extra `-`?
 	// See iam_test for the test.
 	namePostfix = "-iamrole"
-
-	// This is just the local reference name
-	dependencyNamePostfix = "iamrole"
 )
 
 type ResourceWithIamAccessibleBinding struct {
@@ -47,10 +44,7 @@ func PluginServiceInstance(computeType iam_plugin.ComputeType, stateResourceName
 	dependencyReferences := make([]smith_v1.Reference, 0, len(iamShapedResources))
 	iamPolicyDocumentRefs := make(map[string]string, len(iamShapedResources))
 	for _, iamShapedResource := range iamShapedResources {
-		ref := iamShapedResource.BindableIamAccessibleShape.Data.IAMPolicySnippet.ToReference(
-			wiringutil.ReferenceName(iamShapedResource.BindingName, dependencyNamePostfix),
-			iamShapedResource.BindingName,
-		)
+		ref := iamShapedResource.BindableIamAccessibleShape.Data.IAMPolicySnippet.ToReference(iamShapedResource.BindingName)
 		dependencyReferences = append(dependencyReferences, ref)
 		iamPolicyDocumentRefs[string(iamShapedResource.ResourceName)] = ref.Ref()
 	}

--- a/pkg/orchestration/wiring/wiringutil/iam/iam_test.go
+++ b/pkg/orchestration/wiring/wiringutil/iam/iam_test.go
@@ -27,7 +27,7 @@ func TestNames(t *testing.T) {
 	protoReference := libshapes.ProtoReference{
 		Resource: "instance1",
 	}
-	potentiallyConflictingBinding := wiringutil.ConsumerProducerServiceBinding(computeName, someProducerName, protoReference)
+	potentiallyConflictingBinding := wiringutil.ConsumerProducerServiceBinding(computeName, someProducerName, protoReference.ToReference())
 
 	assert.NotEqual(t, potentiallyConflictingBinding.Name, iamBinding.Name)
 	assert.NotEqual(t, potentiallyConflictingBinding.Spec.Object.(meta_v1.Object).GetName(),

--- a/pkg/orchestration/wiring/wiringutil/knownshapes/bindable_iam_accessible.go
+++ b/pkg/orchestration/wiring/wiringutil/knownshapes/bindable_iam_accessible.go
@@ -8,7 +8,8 @@ import (
 
 const (
 	// BindableIamAccessibleShape is a When you bind to it it returns IAM policy snippet.
-	BindableIamAccessibleShape wiringplugin.ShapeName = "voyager.atl-paas.net/BindableIamAccessible"
+	BindableIamAccessibleShape          wiringplugin.ShapeName = "voyager.atl-paas.net/BindableIamAccessible"
+	iamPolicySnippetReferenceNameSuffix                        = "policySnippet"
 )
 
 // +k8s:deepcopy-gen=true
@@ -39,7 +40,8 @@ func NewBindableIamAccessible(resourceName smith_v1.ResourceName, iamPolicySnipp
 					Example:  "aname",
 				}},
 			IAMPolicySnippet: libshapes.BindingSecretProtoReference{
-				Path: iamPolicySnippetPath,
+				Path:        iamPolicySnippetPath,
+				NamePostfix: iamPolicySnippetReferenceNameSuffix,
 			},
 		},
 	}

--- a/pkg/orchestration/wiring/wiringutil/knownshapes/ingress_endpoint.go
+++ b/pkg/orchestration/wiring/wiringutil/knownshapes/ingress_endpoint.go
@@ -12,6 +12,7 @@ const (
 
 	kubeIngressRefMetadataEndpointPath = "metadata.annotations['atlassian\\.com/ingress\\.endpoint']"
 	kubeIngressRefExample              = "ingress-internal-01.ap-southeast-2.paas-dev1.kitt-inf.net"
+	kubeIngressReferenceEndpointSuffix = "endpoint"
 )
 
 // +k8s:deepcopy-gen=true
@@ -33,9 +34,10 @@ func NewIngressEndpoint(resourceName smith_v1.ResourceName) *IngressEndpoint {
 		},
 		Data: IngressEndpointData{
 			IngressEndpoint: libshapes.ProtoReference{
-				Resource: resourceName,
-				Path:     kubeIngressRefMetadataEndpointPath,
-				Example:  kubeIngressRefExample,
+				Resource:    resourceName,
+				Path:        kubeIngressRefMetadataEndpointPath,
+				Example:     kubeIngressRefExample,
+				NamePostfix: kubeIngressReferenceEndpointSuffix,
 			},
 		},
 	}

--- a/pkg/orchestration/wiring/wiringutil/knownshapes/sns_subscribable.go
+++ b/pkg/orchestration/wiring/wiringutil/knownshapes/sns_subscribable.go
@@ -13,7 +13,8 @@ const (
 
 	// This has to match up with what ends up in the bind credentials for
 	// something that emits a topic.
-	snsTopicArnOutputNameKey = "TopicArn"
+	snsTopicArnOutputNameKey       = "TopicArn"
+	snsTopicArnReferenceNameSuffix = "topicArn"
 )
 
 // +k8s:deepcopy-gen=true
@@ -42,8 +43,9 @@ func NewSnsSubscribable(smithResourceName smith_v1.ResourceName) *SnsSubscribabl
 					Example:  "aname",
 				}},
 			TopicARN: libshapes.BindingSecretProtoReference{
-				Path:    fmt.Sprintf("data.%s", snsTopicArnOutputNameKey),
-				Example: `"arn:aws:sns:us-east-1:123456789012:example"`,
+				Path:        fmt.Sprintf("data.%s", snsTopicArnOutputNameKey),
+				Example:     `"arn:aws:sns:us-east-1:123456789012:example"`,
+				NamePostfix: snsTopicArnReferenceNameSuffix,
 			},
 		},
 	}

--- a/pkg/orchestration/wiring/wiringutil/libshapes/BUILD.bazel
+++ b/pkg/orchestration/wiring/wiringutil/libshapes/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/orchestration/wiring/wiringplugin:go_default_library",
+        "//pkg/orchestration/wiring/wiringutil:go_default_library",
         "//vendor/github.com/atlassian/smith/pkg/apis/smith/v1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/orchestration/wiring/wiringutil/libshapes/libshapes.go
+++ b/pkg/orchestration/wiring/wiringutil/libshapes/libshapes.go
@@ -5,6 +5,7 @@ import (
 
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringplugin"
+	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -13,17 +14,21 @@ import (
 // construct a valid Smith reference.
 // +k8s:deepcopy-gen=true
 type ProtoReference struct {
-	Resource smith_v1.ResourceName `json:"resource"`
-	Path     string                `json:"path,omitempty"`
-	Example  interface{}           `json:"example,omitempty"`
-	Modifier string                `json:"modifier,omitempty"`
+	Resource    smith_v1.ResourceName `json:"resource"`
+	Path        string                `json:"path,omitempty"`
+	Example     interface{}           `json:"example,omitempty"`
+	Modifier    string                `json:"modifier,omitempty"`
+	NamePostfix string                `json:"namePostfix,omitempty"`
 }
 
 // ToReference should be used to augment ProtoReference with missing information to
 // get a full Reference.
-func (r *ProtoReference) ToReference(name smith_v1.ReferenceName) smith_v1.Reference {
+func (r *ProtoReference) ToReference(nameElems ...string) smith_v1.Reference {
+	if r.NamePostfix != "" {
+		nameElems = append([]string{r.NamePostfix}, nameElems...)
+	}
 	return smith_v1.Reference{
-		Name:     name,
+		Name:     wiringutil.ReferenceName(r.Resource, nameElems...),
 		Resource: r.Resource,
 		Path:     r.Path,
 		Example:  r.Example,
@@ -41,8 +46,9 @@ func (r *ProtoReference) DeepCopyInto(out *ProtoReference) {
 // BindingProtoReference is a reference to the ServiceBinding's contents.
 // +k8s:deepcopy-gen=true
 type BindingProtoReference struct {
-	Path    string      `json:"path,omitempty"`
-	Example interface{} `json:"example,omitempty"`
+	Path        string      `json:"path,omitempty"`
+	Example     interface{} `json:"example,omitempty"`
+	NamePostfix string      `json:"namePostfix,omitempty"`
 }
 
 func (r *BindingProtoReference) DeepCopyInto(out *BindingProtoReference) {
@@ -52,9 +58,12 @@ func (r *BindingProtoReference) DeepCopyInto(out *BindingProtoReference) {
 
 // ToReference should be used to augment BindingProtoReference with missing information to
 // get a full Reference.
-func (r *BindingProtoReference) ToReference(name smith_v1.ReferenceName, bindingResourceName smith_v1.ResourceName) smith_v1.Reference {
+func (r *BindingProtoReference) ToReference(bindingResourceName smith_v1.ResourceName, nameElems ...string) smith_v1.Reference {
+	if r.NamePostfix != "" {
+		nameElems = append([]string{r.NamePostfix}, nameElems...)
+	}
 	return smith_v1.Reference{
-		Name:     name,
+		Name:     wiringutil.ReferenceName(bindingResourceName, nameElems...),
 		Resource: bindingResourceName,
 		Path:     r.Path,
 		Example:  r.Example,
@@ -64,8 +73,9 @@ func (r *BindingProtoReference) ToReference(name smith_v1.ReferenceName, binding
 // BindingProtoReference is a reference to the ServiceBinding's Secret's contents.
 // +k8s:deepcopy-gen=true
 type BindingSecretProtoReference struct {
-	Path    string      `json:"path,omitempty"`
-	Example interface{} `json:"example,omitempty"`
+	Path        string      `json:"path,omitempty"`
+	Example     interface{} `json:"example,omitempty"`
+	NamePostfix string      `json:"namePostfix,omitempty"`
 }
 
 func (r *BindingSecretProtoReference) DeepCopyInto(out *BindingSecretProtoReference) {
@@ -75,9 +85,12 @@ func (r *BindingSecretProtoReference) DeepCopyInto(out *BindingSecretProtoRefere
 
 // ToReference should be used to augment BindingSecretProtoReference with missing information to
 // get a full Reference.
-func (r *BindingSecretProtoReference) ToReference(name smith_v1.ReferenceName, bindingResourceName smith_v1.ResourceName) smith_v1.Reference {
+func (r *BindingSecretProtoReference) ToReference(bindingResourceName smith_v1.ResourceName, nameElems ...string) smith_v1.Reference {
+	if r.NamePostfix != "" {
+		nameElems = append([]string{r.NamePostfix}, nameElems...)
+	}
 	return smith_v1.Reference{
-		Name:     name,
+		Name:     wiringutil.ReferenceName(bindingResourceName, nameElems...),
 		Resource: bindingResourceName,
 		Path:     r.Path,
 		Example:  r.Example,

--- a/pkg/orchestration/wiring/wiringutil/service_binding.go
+++ b/pkg/orchestration/wiring/wiringutil/service_binding.go
@@ -3,7 +3,6 @@ package wiringutil
 import (
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/voyager"
-	"github.com/atlassian/voyager/pkg/orchestration/wiring/wiringutil/libshapes"
 	sc_v1b1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,11 +15,9 @@ import (
 // there is a need to bind to multiple ServiceInstances produced by the same producer, construct names
 // (using ConsumerProducerResourceNameWithPostfix() and ConsumerProducerMetaNameWithPostfix() functions) with
 // different postfixes.
-func ConsumerProducerServiceBinding(consumer, producer voyager.ResourceName, resourceReference libshapes.ProtoReference) smith_v1.Resource {
+func ConsumerProducerServiceBinding(consumer, producer voyager.ResourceName, serviceInstanceRef smith_v1.Reference) smith_v1.Resource {
 	bindingResourceName := ConsumerProducerResourceNameWithPostfix(consumer, producer, "binding")
 	bindingMetaName := ConsumerProducerMetaName(consumer, producer)
-	referenceName := ReferenceName(resourceReference.Resource, "metadata", "name")
-	serviceInstanceRef := resourceReference.ToReference(referenceName)
 	return ServiceBinding(bindingResourceName, bindingMetaName, serviceInstanceRef)
 }
 

--- a/pkg/orchestration/wiring/wiringutil/util.go
+++ b/pkg/orchestration/wiring/wiringutil/util.go
@@ -4,9 +4,17 @@ import (
 	"reflect"
 	"strings"
 
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 )
+
+// IsSameTarget tests if two references refer to the same target.
+func IsSameTarget(a, b smith_v1.Reference) bool {
+	return a.Resource == b.Resource &&
+		a.Path == b.Path &&
+		a.Modifier == b.Modifier
+}
 
 // Merge two maps, only use loser's fields if those fields are missing in winner
 func Merge(winner, loser map[string]interface{}) (map[string]interface{}, error) {


### PR DESCRIPTION
First commit simplifies the way names for proto references are constructed, second one fixed the equality check for references. `example` and `name` of the references should not be compared to determine if both refer to the same target. We are got lucky here because we have those fields set to the same values and no extra bindings have been provisioned.