### PR TITLE
Update Ctrl version, propogate external errors up to ctrl layer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -100,7 +100,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3b68cf4e03d5b40a7d4aa40f3ce9c48d34ef4bcef9e255fc7fe37df0be1c9bb4"
+  digest = "1:a91d278d1ba3f4d51548531a3601548ee25f30a963b7de67607fdac9af0d9f3a"
   name = "github.com/atlassian/ctrl"
   packages = [
     ".",
@@ -113,11 +113,11 @@
     "process",
   ]
   pruneopts = "NT"
-  revision = "30152a801242bb7aa023702c184d4aa919dab4bc"
+  revision = "1cea8338282d871a8fd8c2cebd24ad177b25240e"
 
 [[projects]]
   branch = "master"
-  digest = "1:0835f1107a6bded6259fafdebb83e1ece5601798159f662ead1f00afe284cddf"
+  digest = "1:3ed06deb6bb3549e1cffbb15bfc967105827ed80bea52fee52a2513b4b5a1468"
   name = "github.com/atlassian/smith"
   packages = [
     ".",
@@ -144,7 +144,7 @@
     "pkg/util/logz",
   ]
   pruneopts = "NT"
-  revision = "40d683b56ef03c9637f8a756d3d3886408a434d7"
+  revision = "e4fa63e5dcb5b4dc532a3dcb7b93ca4a5ad19438"
 
 [[projects]]
   digest = "1:07918ac16957399fa68bf94b3ab26dccccc6992f1ccbcf589896734569a0a7e7"

--- a/pkg/composition/controller_test.go
+++ b/pkg/composition/controller_test.go
@@ -252,9 +252,11 @@ func TestCreatesLocationDescriptorNoLabel(t *testing.T) {
 			},
 		},
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			ld, ok := findCreatedLocationDescriptor(tc.formFake.Actions())
 			require.True(t, ok)
@@ -314,9 +316,11 @@ func TestCreatesLocationDescriptorWithTransformedResources(t *testing.T) {
 			},
 		},
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			ld, ok := findCreatedLocationDescriptor(tc.formFake.Actions())
 			require.True(t, ok)
@@ -368,9 +372,11 @@ func TestCreatesLocationDescriptorWithLabel(t *testing.T) {
 	tc := testCase{
 		sd: sd,
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			ld, ok := findCreatedLocationDescriptor(tc.formFake.Actions())
 			require.True(t, ok)
@@ -457,9 +463,11 @@ func TestUpdatesLocationDescriptorNoLabel(t *testing.T) {
 			},
 		},
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			ld, ok := findUpdatedLocationDescriptor(tc.formFake.Actions())
 			require.True(t, ok)
@@ -541,9 +549,11 @@ func TestDoesNotSkipLocationDescriptorUpdateWhenLocationDescriptorBeingDeleted(t
 			},
 		},
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			_, ok := findCreatedLocationDescriptor(tc.formFake.Actions())
 			assert.False(t, ok)
@@ -601,9 +611,11 @@ func TestLocationDescriptorErrorsWhenDifferentOwnerReference(t *testing.T) {
 			},
 		},
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 
 			assert.Error(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			_, ok := findCreatedLocationDescriptor(tc.formFake.Actions())
 			require.False(t, ok)
@@ -632,9 +644,11 @@ func TestSkipsLocationWhenControllerHasNamespace(t *testing.T) {
 		},
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
 			cntrlr.namespace = "some-random-ns"
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			_, found := findCreatedNamespace(tc.mainFake.Actions())
 			require.False(t, found)
@@ -665,8 +679,10 @@ func TestServiceDescriptorUpdatedIfStatusChanges(t *testing.T) {
 	tc := testCase{
 		sd: sd,
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			// Descriptor should have updated with a bunch of statuses
 			sd, ok := findUpdatedServiceDescriptor(tc.compFake.Actions())
@@ -702,8 +718,10 @@ func TestServiceDescriptorFinalizerAdded(t *testing.T) {
 	tc := testCase{
 		sd: sd,
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			// Descriptor should have updated with a bunch of statuses
 			sd, ok := findUpdatedServiceDescriptor(tc.compFake.Actions())
@@ -745,8 +763,10 @@ func TestDeleteServiceDescriptorFinalizerRemoved(t *testing.T) {
 	tc := testCase{
 		sd: sd,
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			// Descriptor should have updated with a bunch of statuses
 			sd, ok := findUpdatedServiceDescriptor(tc.compFake.Actions())
@@ -825,8 +845,10 @@ func TestServiceDescriptorNotUpdatedIfStatusNotChanged(t *testing.T) {
 	tc := testCase{
 		sd: sd,
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			// Descriptor should have updated with a bunch of statuses
 			_, ok := findUpdatedServiceDescriptor(tc.compFake.Actions())
@@ -1028,8 +1050,10 @@ func TestServiceDescriptorCopiesLdStatus(t *testing.T) {
 		mainClientObjects: []runtime.Object{existingNamespace, unreferencedNamespace},
 
 		test: func(t *testing.T, cntrlr *Controller, ctx *ctrl.ProcessContext, tc *testCase) {
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			// Descriptor should have updated with a bunch of statuses
 			sd, ok := findUpdatedServiceDescriptor(tc.compFake.Actions())
@@ -1200,8 +1224,10 @@ func TestServiceDescriptorCopiesLdStatusWhenDeleting(t *testing.T) {
 				return true, nil, nil
 			})
 
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			// Descriptor should have updated with a bunch of statuses
 			sd, ok := findUpdatedServiceDescriptor(tc.compFake.Actions())

--- a/pkg/formation/BUILD.bazel
+++ b/pkg/formation/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/k8s:go_default_library",
         "//pkg/orchestration/client/fake:go_default_library",
         "//pkg/orchestration/informer:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/testutil:go_default_library",
         "//vendor/github.com/ash2k/stager:go_default_library",
         "//vendor/github.com/atlassian/ctrl:go_default_library",

--- a/pkg/ops/controller.go
+++ b/pkg/ops/controller.go
@@ -28,14 +28,14 @@ func (c *Controller) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (c *Controller) Process(ctx *ctrl.ProcessContext) (retriable bool, err error) {
+func (c *Controller) Process(ctx *ctrl.ProcessContext) (externalErr bool, retriable bool, err error) {
 	route := ctx.Object.(*ops_v1.Route)
 
 	conflict, retriable, err := c.process(route)
 	if conflict {
-		return false, nil
+		return false, false, nil
 	}
-	return retriable, err
+	return false, retriable, err
 }
 
 func (c *Controller) process(route *ops_v1.Route) (conflictRet, retriableRet bool, e error) {

--- a/pkg/replication/controller_test.go
+++ b/pkg/replication/controller_test.go
@@ -11,6 +11,7 @@ import (
 	compclient_fake "github.com/atlassian/voyager/pkg/composition/client/fake"
 	compInf "github.com/atlassian/voyager/pkg/composition/informer"
 	k8s_testing "github.com/atlassian/voyager/pkg/k8s/testing"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -39,8 +40,10 @@ func TestCreateServiceDescriptor(t *testing.T) {
 				},
 			}
 			pctx.Object = desiredSD
-			_, err := cntrlr.Process(pctx)
+			external, retriable, err := cntrlr.Process(pctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			actions := tc.sdFake.Actions()
 
@@ -85,8 +88,10 @@ func TestUpdateServiceDescriptor(t *testing.T) {
 			}
 
 			pctx.Object = desiredSD
-			_, err := cntrlr.Process(pctx)
+			external, retriable, err := cntrlr.Process(pctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			actions := tc.sdFake.Actions()
 
@@ -122,8 +127,10 @@ func TestUpdateServiceDescriptorNoOp(t *testing.T) {
 			newSD.SetGroupVersionKind(comp_v1.ServiceDescriptorGVK)
 			pctx.Object = newSD
 
-			_, err := cntrlr.Process(pctx)
+			external, retriable, err := cntrlr.Process(pctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			actions := tc.sdFake.Actions()
 
@@ -171,8 +178,10 @@ func TestSkipReplicationOfExisting(t *testing.T) {
 			}
 			pctx.Object = desiredSD
 
-			_, err := cntrlr.Process(pctx)
+			external, retriable, err := cntrlr.Process(pctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			actions := tc.sdFake.Actions()
 
@@ -222,8 +231,10 @@ func TestSkipReplicationOfDesired(t *testing.T) {
 			}
 			pctx.Object = desiredSD
 
-			_, err := cntrlr.Process(pctx)
+			external, retriable, err := cntrlr.Process(pctx)
 			require.NoError(t, err)
+			assert.False(t, external, "error should not be an external error")
+			assert.False(t, retriable, "error should not be an external error")
 
 			actions := tc.sdFake.Actions()
 

--- a/pkg/synchronization/roles_test.go
+++ b/pkg/synchronization/roles_test.go
@@ -57,8 +57,10 @@ func TestCreatesRoleBindingsFromServiceCentralData(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external)
+			assert.False(t, retriable)
 
 			actions := tc.mainFake.Actions()
 
@@ -180,8 +182,10 @@ func TestSkipsUpdateOfRoleBindingsIfNoChange(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external)
+			assert.False(t, retriable)
 
 			actions := tc.mainFake.Actions()
 
@@ -229,8 +233,10 @@ func TestEmptyBuildRoleBindingsWhenListsEmpty(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external)
+			assert.False(t, retriable)
 
 			actions := tc.mainFake.Actions()
 
@@ -278,8 +284,10 @@ func TestEmptyRoleBindingsNonExistantBuilds(t *testing.T) {
 
 			tc.scFake.On("GetService", mock.Anything, auth.NoUser(), serviceNameSc).Return(service, nil)
 
-			_, err := cntrlr.Process(ctx)
+			external, retriable, err := cntrlr.Process(ctx)
 			require.NoError(t, err)
+			assert.False(t, external)
+			assert.False(t, retriable)
 
 			actions := tc.mainFake.Actions()
 

--- a/vendor/github.com/atlassian/ctrl/process/generic.go
+++ b/vendor/github.com/atlassian/ctrl/process/generic.go
@@ -119,7 +119,7 @@ func NewGeneric(config *ctrl.Config, queue workqueue.RateLimitingInterface, work
 					Name:      "process_object_errors_total",
 					Help:      "Records the number of times an error was triggered while processing an object",
 				},
-				[]string{"controller", "object_namespace", "object", "groupkind", "retriable"},
+				[]string{"controller", "object_namespace", "object", "groupkind", "external", "retriable"},
 			)
 
 			holders[descr.Gvk] = Holder{

--- a/vendor/github.com/atlassian/ctrl/types.go
+++ b/vendor/github.com/atlassian/ctrl/types.go
@@ -53,7 +53,15 @@ type Constructor interface {
 
 type Interface interface {
 	Run(context.Context)
-	Process(*ProcessContext) (retriable bool, err error)
+
+	// Process is implemented by the controller and returns:
+	// - true for externalErr if the error is not an internal error
+	// - true for retriableErr if the error is a retriable error (i.e. should be
+	//   added back to the work queue). These are retried for limited number of
+	//   attempts
+	// - an error, if there is an error, or nil. If there is no error, the above
+	//   two bools (externalErr and retriableErr) are ignored.
+	Process(*ProcessContext) (externalErr bool, retriableErr bool, err error)
 }
 
 type WorkQueueProducer interface {

--- a/vendor/github.com/atlassian/smith/pkg/controller/bundlec/resource_sync_task.go
+++ b/vendor/github.com/atlassian/smith/pkg/controller/bundlec/resource_sync_task.go
@@ -640,6 +640,7 @@ func (st *resourceSyncTask) validateSpec(spec *unstructured.Unstructured) resour
 				return resourceStatusError{
 					err:              errors.Errorf("annotation %q cannot be set by the user", key),
 					isRetriableError: false,
+					isExternalError:  true,
 				}
 			}
 		}


### PR DESCRIPTION
This bumps the version of Ctrl.

As a result, I also needed to change everything to fit the new interface, which meant bubbling external errors up to the ctrl layer instead of hiding them.