### PR TITLE
MICROS-6976 PDB name should change if configuration changes

### DIFF
--- a/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/asapkey.basicdep.bundle.yaml
@@ -140,7 +140,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/e2e.tests.bundle.yaml
@@ -1342,7 +1342,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kc--svcacc
-  - name: kc--pdb
+  - name: kc--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.basicdep.bundle.yaml
@@ -164,7 +164,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.datadog.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.datadog.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nodefaults.bundle.yaml
@@ -164,7 +164,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.nohpa.bundle.yaml
@@ -164,7 +164,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.pdb.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.pdb.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: c1--svcacc
-  - name: c1--pdb
+  - name: c1--pdb-minavail-66
     spec:
       object:
         apiVersion: policy/v1beta1
@@ -210,7 +210,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: c2--svcacc
-  - name: c2--pdb
+  - name: c2--pdb-minavail-50
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.probes.nodefaults.bundle.yaml
@@ -164,7 +164,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.rename.bundle.yaml
@@ -164,7 +164,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.sameminmax.bundle.yaml
@@ -164,7 +164,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.scaling.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-66
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.simple.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingress.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressanddefaulttimeout.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandlabel.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/k8scompute.withingressandtimeout.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/platformdns.multipleresources.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/platformdns.multipleresources.bundle.yaml
@@ -22,7 +22,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: c1--svcacc
-  - name: c1--pdb
+  - name: c1--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1
@@ -145,7 +145,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: c2--svcacc
-  - name: c2--pdb
+  - name: c2--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/saml.basic.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/saml.basic.bundle.yaml
@@ -130,7 +130,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1

--- a/pkg/orchestration/wiring/testdata/saml.label.bundle.yaml
+++ b/pkg/orchestration/wiring/testdata/saml.label.bundle.yaml
@@ -131,7 +131,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: kubecompute-simple--svcacc
-  - name: kubecompute-simple--pdb
+  - name: kubecompute-simple--pdb-minavail-0
     spec:
       object:
         apiVersion: policy/v1beta1


### PR DESCRIPTION
PodDisruptionBudget is immutable and can't be modified by smith, therefore if we change the config, we need to give the object a new name.