### PR TITLE
Fix error message when deleting existing container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ALL_DIRS=$(APIS_AGGREGATOR_DIR),$(APIS_COMPOSITION_DIR),$(APIS_CREATOR_DIR),$(AP
 #===============================================================================
 
 define check-git-status
-if [[ -n $$(git --no-pager status -s 2> /dev/null) ]] ;\
+if [ -n "$$(git --no-pager status -s 2> /dev/null)" ] ;\
 then \
 	echo "Git tree is not clean. Did you forget to commit some files? If you added new dependency please use dep ensure -add before creating PR." ;\
 	git --no-pager status ;\
@@ -30,7 +30,7 @@ fi
 endef
 
 define check-git-status-in-ci
-if [[ -n $$(git --no-pager status -s 2> /dev/null) ]] ;\
+if [ -n "$$(git --no-pager status -s 2> /dev/null)" ] ;\
 then \
 	echo "Git tree is not clean. Did you forget to commit some files? If you added new dependency please use dep ensure -add before creating PR." ;\
 	git --no-pager status ;\

--- a/pkg/creator/ssam/client.go
+++ b/pkg/creator/ssam/client.go
@@ -326,7 +326,7 @@ func (c clientImpl) DeleteContainer(ctx context.Context, containerShortName stri
 	logger.Debug("SSAM GetContainer", zappers.ContainerShortName(containerShortName))
 
 	if err := validateShortName(containerShortName); err != nil {
-		logger.Warn("SSAM GetContainer name %q does not obey naming scheme, will attempt to delete anyway",
+		logger.Warn("SSAM container name %q does not obey naming scheme, will attempt to delete anyway",
 			zappers.ContainerShortName(containerShortName))
 	}
 

--- a/pkg/creator/ssam/client.go
+++ b/pkg/creator/ssam/client.go
@@ -326,8 +326,8 @@ func (c clientImpl) DeleteContainer(ctx context.Context, containerShortName stri
 	logger.Debug("SSAM GetContainer", zappers.ContainerShortName(containerShortName))
 
 	if err := validateShortName(containerShortName); err != nil {
-		return err
-
+		logger.Warn("SSAM GetContainer name %q does not obey naming scheme, will attempt to delete anyway",
+			zappers.ContainerShortName(containerShortName))
 	}
 
 	// Delete the container

--- a/pkg/creator/ssam/client_test.go
+++ b/pkg/creator/ssam/client_test.go
@@ -227,7 +227,7 @@ func TestSSAMClientDeleteContainerSuccessTypical(t *testing.T) {
 func TestSSAMClientDeleteContainerSuccessNonCompliantName(t *testing.T) {
 	t.Parallel()
 
-	containerShortName := "whatever-2.0"  // not supposed to contain dots
+	containerShortName := "whatever-2.0" // not supposed to contain dots
 
 	// GIVEN: Setup mock server to respond with testdata/
 	handler := MockHandler(Match(AnyRequest).Respond(


### PR DESCRIPTION
For ssam containers that were somehow created without obeying the naming scheme we currently block deleting them. This allows cleaning them up.